### PR TITLE
feat: add GitLab connector with full hexagonal architecture

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -222,6 +222,36 @@ func (sf *ServiceFactory) CreateHealthService() inbound.HealthService {
 	return service.NewHealthServiceAdapter(repositoryRepo, indexingJobRepo, messagePublisher, serviceVersion)
 }
 
+// CreateConnectorService creates a connector service instance.
+func (sf *ServiceFactory) CreateConnectorService() inbound.ConnectorService {
+	dbPool, err := sf.GetDatabasePool()
+	if err != nil {
+		slogger.ErrorNoCtx("Failed to create database connection for connector service", slogger.Fields{
+			"error": err.Error(),
+		})
+		os.Exit(1)
+	}
+	connectorRepo := repository.NewPostgreSQLConnectorRepository(dbPool)
+	return service.NewConnectorServiceAdapter(connectorRepo)
+}
+
+// ReconcileConnectors runs config-driven connector reconciliation at startup.
+// Non-fatal: logs and continues if reconciliation fails.
+func (sf *ServiceFactory) ReconcileConnectors(ctx context.Context) {
+	dbPool, err := sf.GetDatabasePool()
+	if err != nil {
+		slogger.Error(ctx, "Connector reconciliation skipped: database unavailable", slogger.Fields{
+			"error": err.Error(),
+		})
+		return
+	}
+	connectorRepo := repository.NewPostgreSQLConnectorRepository(dbPool)
+	reconciler := appservice.NewConnectorReconciler(connectorRepo)
+	if err := reconciler.Reconcile(ctx, sf.config.Connectors); err != nil {
+		slogger.Error(ctx, "Connector reconciliation failed", slogger.Fields{"error": err.Error()})
+	}
+}
+
 // CreateRepositoryService creates a repository service instance with fail-fast error handling.
 //
 // This method uses buildDependencies to create the required database repositories and message publisher.
@@ -433,6 +463,7 @@ func (sf *ServiceFactory) CreateServer() (*api.Server, error) {
 	// Create all services
 	healthService := sf.CreateHealthService()
 	repositoryService := sf.CreateRepositoryService()
+	connectorService := sf.CreateConnectorService()
 	errorHandler := sf.CreateErrorHandler()
 
 	// Create search service - fail fast if creation fails (e.g., missing Gemini API key)
@@ -449,6 +480,7 @@ func (sf *ServiceFactory) CreateServer() (*api.Server, error) {
 	serverBuilder := api.NewServerBuilder(sf.config).
 		WithHealthService(healthService).
 		WithRepositoryService(repositoryService).
+		WithConnectorService(connectorService).
 		WithErrorHandler(errorHandler)
 
 	// Add search service if available
@@ -558,6 +590,10 @@ func runAPIServer(_ *cobra.Command, _ []string) {
 
 	// Create service factory
 	serviceFactory := NewServiceFactory(cfg)
+
+	// Reconcile connectors from config before serving traffic.
+	reconcileCtx := context.Background()
+	serviceFactory.ReconcileConnectors(reconcileCtx)
 
 	// Create server using the factory
 	server, err := serviceFactory.CreateServer()

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -96,3 +96,17 @@ client:
   repos:
     poll_interval: 5s   # matches client.DefaultPollInterval
     wait_timeout: 30m   # matches client.DefaultMaxWait
+
+# Connectors are managed declaratively here; the API is read-only for connectors.
+# Auth tokens support environment variable expansion: ${GITLAB_TOKEN}
+#
+# connectors:
+#   - name: "my-gitlab"
+#     type: "gitlab"
+#     base_url: "https://gitlab.com"
+#     auth_token: "${GITLAB_TOKEN}"
+#     groups:
+#       - "my-group"
+#       - "another-group"
+#     projects:
+#       - "my-group/my-project"

--- a/internal/adapter/inbound/api/connector_handler.go
+++ b/internal/adapter/inbound/api/connector_handler.go
@@ -1,0 +1,101 @@
+package api
+
+import (
+	"codechunking/internal/application/common/slogger"
+	"codechunking/internal/application/dto"
+	"codechunking/internal/port/inbound"
+	"net/http"
+	"strconv"
+
+	"github.com/google/uuid"
+)
+
+// ConnectorHandler handles HTTP requests for connector operations.
+// The API is read-only; connectors are managed via config file reconciliation.
+type ConnectorHandler struct {
+	connectorService inbound.ConnectorService
+	errorHandler     ErrorHandler
+}
+
+// NewConnectorHandler creates a new ConnectorHandler.
+func NewConnectorHandler(connectorService inbound.ConnectorService, errorHandler ErrorHandler) *ConnectorHandler {
+	return &ConnectorHandler{
+		connectorService: connectorService,
+		errorHandler:     errorHandler,
+	}
+}
+
+// ListConnectors handles GET /connectors.
+func (h *ConnectorHandler) ListConnectors(w http.ResponseWriter, r *http.Request) {
+	query := dto.DefaultConnectorListQuery()
+
+	if ct := r.URL.Query().Get("connector_type"); ct != "" {
+		query.ConnectorType = ct
+	}
+	if status := r.URL.Query().Get("status"); status != "" {
+		query.Status = status
+	}
+	if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
+		if v, err := strconv.Atoi(limitStr); err == nil {
+			query.Limit = v
+		}
+	}
+	if offsetStr := r.URL.Query().Get("offset"); offsetStr != "" {
+		if v, err := strconv.Atoi(offsetStr); err == nil {
+			query.Offset = v
+		}
+	}
+
+	response, err := h.connectorService.ListConnectors(r.Context(), query)
+	if err != nil {
+		h.errorHandler.HandleServiceError(w, r, err)
+		return
+	}
+
+	if err := WriteJSON(w, http.StatusOK, response); err != nil {
+		slogger.Error(r.Context(), "failed to write connector response", slogger.Fields{"error": err})
+	}
+}
+
+// GetConnector handles GET /connectors/{id}.
+func (h *ConnectorHandler) GetConnector(w http.ResponseWriter, r *http.Request) {
+	id, err := extractConnectorIDFromPath(r)
+	if err != nil {
+		h.errorHandler.HandleValidationError(w, r, err)
+		return
+	}
+
+	response, err := h.connectorService.GetConnector(r.Context(), id)
+	if err != nil {
+		h.errorHandler.HandleServiceError(w, r, err)
+		return
+	}
+
+	if err := WriteJSON(w, http.StatusOK, response); err != nil {
+		slogger.Error(r.Context(), "failed to write connector response", slogger.Fields{"error": err})
+	}
+}
+
+// SyncConnector handles POST /connectors/{id}/sync.
+func (h *ConnectorHandler) SyncConnector(w http.ResponseWriter, r *http.Request) {
+	id, err := extractConnectorIDFromPath(r)
+	if err != nil {
+		h.errorHandler.HandleValidationError(w, r, err)
+		return
+	}
+
+	response, err := h.connectorService.SyncConnector(r.Context(), id)
+	if err != nil {
+		h.errorHandler.HandleServiceError(w, r, err)
+		return
+	}
+
+	if err := WriteJSON(w, http.StatusAccepted, response); err != nil {
+		slogger.Error(r.Context(), "failed to write connector response", slogger.Fields{"error": err})
+	}
+}
+
+// extractConnectorIDFromPath extracts and validates the "id" path parameter as a UUID.
+func extractConnectorIDFromPath(r *http.Request) (uuid.UUID, error) {
+	return newPathParameterExtractor(r).extractUUIDPathValue("id", "connector")
+}

--- a/internal/adapter/inbound/api/connector_handler_test.go
+++ b/internal/adapter/inbound/api/connector_handler_test.go
@@ -1,0 +1,401 @@
+package api_test
+
+import (
+	"codechunking/internal/adapter/inbound/api"
+	"codechunking/internal/adapter/inbound/api/testutil"
+	"codechunking/internal/application/dto"
+	domainerrors "codechunking/internal/domain/errors/domain"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// MockConnectorService is a local mock for inbound.ConnectorService (read-only).
+type MockConnectorService struct {
+	mu sync.RWMutex
+
+	GetConnectorFunc   func(ctx context.Context, id uuid.UUID) (*dto.ConnectorResponse, error)
+	ListConnectorsFunc func(ctx context.Context, query dto.ConnectorListQuery) (*dto.ConnectorListResponse, error)
+	SyncConnectorFunc  func(ctx context.Context, id uuid.UUID) (*dto.SyncConnectorResponse, error)
+
+	GetConnectorCalls   []getConnectorCall
+	ListConnectorsCalls []listConnectorsCall
+	SyncConnectorCalls  []syncConnectorCall
+}
+
+type getConnectorCall struct {
+	Ctx context.Context
+	ID  uuid.UUID
+}
+
+type listConnectorsCall struct {
+	Ctx   context.Context
+	Query dto.ConnectorListQuery
+}
+
+type syncConnectorCall struct {
+	Ctx context.Context
+	ID  uuid.UUID
+}
+
+func newMockConnectorService() *MockConnectorService {
+	return &MockConnectorService{}
+}
+
+func (m *MockConnectorService) GetConnector(ctx context.Context, id uuid.UUID) (*dto.ConnectorResponse, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.GetConnectorCalls = append(m.GetConnectorCalls, getConnectorCall{Ctx: ctx, ID: id})
+	if m.GetConnectorFunc != nil {
+		return m.GetConnectorFunc(ctx, id)
+	}
+	return nil, errors.New("mock not configured")
+}
+
+func (m *MockConnectorService) ListConnectors(
+	ctx context.Context,
+	query dto.ConnectorListQuery,
+) (*dto.ConnectorListResponse, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.ListConnectorsCalls = append(m.ListConnectorsCalls, listConnectorsCall{Ctx: ctx, Query: query})
+	if m.ListConnectorsFunc != nil {
+		return m.ListConnectorsFunc(ctx, query)
+	}
+	return nil, errors.New("mock not configured")
+}
+
+func (m *MockConnectorService) SyncConnector(
+	ctx context.Context,
+	id uuid.UUID,
+) (*dto.SyncConnectorResponse, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.SyncConnectorCalls = append(m.SyncConnectorCalls, syncConnectorCall{Ctx: ctx, ID: id})
+	if m.SyncConnectorFunc != nil {
+		return m.SyncConnectorFunc(ctx, id)
+	}
+	return nil, errors.New("mock not configured")
+}
+
+func newTestConnectorID() uuid.UUID {
+	return uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+}
+
+func newConnectorResponse(id uuid.UUID, name, status string) dto.ConnectorResponse {
+	now := time.Now()
+	return dto.ConnectorResponse{
+		ID:              id,
+		Name:            name,
+		ConnectorType:   "gitlab",
+		BaseURL:         "https://gitlab.com",
+		Status:          status,
+		RepositoryCount: 0,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+}
+
+// =============================================================================
+// GET /connectors
+// =============================================================================
+
+func TestConnectorHandler_ListConnectors(t *testing.T) {
+	tests := []struct {
+		name           string
+		mockSetup      func(*MockConnectorService)
+		expectedStatus int
+		validateFunc   func(t *testing.T, rec *httptest.ResponseRecorder)
+	}{
+		{
+			name: "successful_list_returns_200",
+			mockSetup: func(m *MockConnectorService) {
+				resp := &dto.ConnectorListResponse{
+					Connectors: []dto.ConnectorResponse{
+						newConnectorResponse(uuid.New(), "connector-1", "active"),
+						newConnectorResponse(uuid.New(), "connector-2", "active"),
+					},
+					Pagination: dto.PaginationResponse{Limit: 20, Offset: 0, Total: 2, HasMore: false},
+				}
+				m.ListConnectorsFunc = func(_ context.Context, _ dto.ConnectorListQuery) (*dto.ConnectorListResponse, error) {
+					return resp, nil
+				}
+			},
+			expectedStatus: http.StatusOK,
+			validateFunc: func(t *testing.T, rec *httptest.ResponseRecorder) {
+				assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+
+				var response dto.ConnectorListResponse
+				err := testutil.ParseJSONResponse(rec, &response)
+				require.NoError(t, err)
+
+				assert.Len(t, response.Connectors, 2)
+				assert.Equal(t, 2, response.Pagination.Total)
+			},
+		},
+		{
+			name: "empty_list_returns_200",
+			mockSetup: func(m *MockConnectorService) {
+				resp := &dto.ConnectorListResponse{
+					Connectors: []dto.ConnectorResponse{},
+					Pagination: dto.PaginationResponse{Limit: 20, Offset: 0, Total: 0, HasMore: false},
+				}
+				m.ListConnectorsFunc = func(_ context.Context, _ dto.ConnectorListQuery) (*dto.ConnectorListResponse, error) {
+					return resp, nil
+				}
+			},
+			expectedStatus: http.StatusOK,
+			validateFunc: func(t *testing.T, rec *httptest.ResponseRecorder) {
+				var response dto.ConnectorListResponse
+				err := testutil.ParseJSONResponse(rec, &response)
+				require.NoError(t, err)
+				assert.Empty(t, response.Connectors)
+			},
+		},
+		{
+			name: "service_error_returns_500",
+			mockSetup: func(m *MockConnectorService) {
+				m.ListConnectorsFunc = func(_ context.Context, _ dto.ConnectorListQuery) (*dto.ConnectorListResponse, error) {
+					return nil, errors.New("database error")
+				}
+			},
+			expectedStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockService := newMockConnectorService()
+			mockErrorHandler := testutil.NewMockErrorHandler()
+			tt.mockSetup(mockService)
+
+			handler := api.NewConnectorHandler(mockService, mockErrorHandler)
+
+			req := testutil.CreateRequest(http.MethodGet, "/connectors")
+			recorder := httptest.NewRecorder()
+
+			handler.ListConnectors(recorder, req)
+
+			assert.Equal(t, tt.expectedStatus, recorder.Code)
+
+			if tt.validateFunc != nil {
+				tt.validateFunc(t, recorder)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// GET /connectors/{id}
+// =============================================================================
+
+func TestConnectorHandler_GetConnector(t *testing.T) {
+	tests := []struct {
+		name           string
+		connectorID    string
+		mockSetup      func(*MockConnectorService)
+		expectedStatus int
+		expectedError  string
+		validateFunc   func(t *testing.T, rec *httptest.ResponseRecorder)
+	}{
+		{
+			name:        "successful_get_returns_200",
+			connectorID: newTestConnectorID().String(),
+			mockSetup: func(m *MockConnectorService) {
+				resp := newConnectorResponse(newTestConnectorID(), "my-connector", "active")
+				m.GetConnectorFunc = func(_ context.Context, _ uuid.UUID) (*dto.ConnectorResponse, error) {
+					return &resp, nil
+				}
+			},
+			expectedStatus: http.StatusOK,
+			validateFunc: func(t *testing.T, rec *httptest.ResponseRecorder) {
+				assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+
+				var response dto.ConnectorResponse
+				err := testutil.ParseJSONResponse(rec, &response)
+				require.NoError(t, err)
+
+				assert.Equal(t, newTestConnectorID(), response.ID)
+				assert.Equal(t, "my-connector", response.Name)
+				assert.Equal(t, "active", response.Status)
+			},
+		},
+		{
+			name:           "missing_id_returns_400",
+			connectorID:    "",
+			mockSetup:      func(_ *MockConnectorService) {},
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "validation error",
+		},
+		{
+			name:           "invalid_uuid_returns_400",
+			connectorID:    "not-a-uuid",
+			mockSetup:      func(_ *MockConnectorService) {},
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "validation error",
+		},
+		{
+			name:        "not_found_returns_404",
+			connectorID: newTestConnectorID().String(),
+			mockSetup: func(m *MockConnectorService) {
+				m.GetConnectorFunc = func(_ context.Context, _ uuid.UUID) (*dto.ConnectorResponse, error) {
+					return nil, domainerrors.ErrConnectorNotFound
+				}
+			},
+			expectedStatus: http.StatusNotFound,
+			expectedError:  "service error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockService := newMockConnectorService()
+			mockErrorHandler := testutil.NewMockErrorHandler()
+			tt.mockSetup(mockService)
+
+			handler := api.NewConnectorHandler(mockService, mockErrorHandler)
+
+			pathParams := map[string]string{}
+			if tt.connectorID != "" {
+				pathParams["id"] = tt.connectorID
+			}
+			req := testutil.CreateRequestWithPathParams(http.MethodGet, "/connectors/"+tt.connectorID, pathParams)
+			recorder := httptest.NewRecorder()
+
+			handler.GetConnector(recorder, req)
+
+			assert.Equal(t, tt.expectedStatus, recorder.Code)
+
+			if tt.expectedError != "" {
+				assert.Contains(t, recorder.Body.String(), tt.expectedError)
+			}
+
+			if tt.validateFunc != nil {
+				tt.validateFunc(t, recorder)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// POST /connectors/{id}/sync
+// =============================================================================
+
+func TestConnectorHandler_SyncConnector(t *testing.T) {
+	tests := []struct {
+		name           string
+		connectorID    string
+		mockSetup      func(*MockConnectorService)
+		expectedStatus int
+		expectedError  string
+		validateFunc   func(t *testing.T, rec *httptest.ResponseRecorder)
+	}{
+		{
+			name:        "successful_sync_returns_202",
+			connectorID: newTestConnectorID().String(),
+			mockSetup: func(m *MockConnectorService) {
+				resp := &dto.SyncConnectorResponse{
+					ConnectorID:       newTestConnectorID(),
+					RepositoriesFound: 25,
+					Message:           "sync triggered successfully",
+				}
+				m.SyncConnectorFunc = func(_ context.Context, _ uuid.UUID) (*dto.SyncConnectorResponse, error) {
+					return resp, nil
+				}
+			},
+			expectedStatus: http.StatusAccepted,
+			validateFunc: func(t *testing.T, rec *httptest.ResponseRecorder) {
+				assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+
+				var response dto.SyncConnectorResponse
+				err := testutil.ParseJSONResponse(rec, &response)
+				require.NoError(t, err)
+
+				assert.Equal(t, newTestConnectorID(), response.ConnectorID)
+				assert.Equal(t, 25, response.RepositoriesFound)
+				assert.NotEmpty(t, response.Message)
+			},
+		},
+		{
+			name:           "missing_id_returns_400",
+			connectorID:    "",
+			mockSetup:      func(_ *MockConnectorService) {},
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "validation error",
+		},
+		{
+			name:           "invalid_uuid_returns_400",
+			connectorID:    "bad-uuid",
+			mockSetup:      func(_ *MockConnectorService) {},
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "validation error",
+		},
+		{
+			name:        "not_found_returns_404",
+			connectorID: newTestConnectorID().String(),
+			mockSetup: func(m *MockConnectorService) {
+				m.SyncConnectorFunc = func(_ context.Context, _ uuid.UUID) (*dto.SyncConnectorResponse, error) {
+					return nil, domainerrors.ErrConnectorNotFound
+				}
+			},
+			expectedStatus: http.StatusNotFound,
+			expectedError:  "service error",
+		},
+		{
+			name:        "already_syncing_returns_409",
+			connectorID: newTestConnectorID().String(),
+			mockSetup: func(m *MockConnectorService) {
+				m.SyncConnectorFunc = func(_ context.Context, _ uuid.UUID) (*dto.SyncConnectorResponse, error) {
+					return nil, domainerrors.ErrConnectorSyncing
+				}
+			},
+			expectedStatus: http.StatusConflict,
+			expectedError:  "service error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockService := newMockConnectorService()
+			mockErrorHandler := testutil.NewMockErrorHandler()
+			tt.mockSetup(mockService)
+
+			handler := api.NewConnectorHandler(mockService, mockErrorHandler)
+
+			pathParams := map[string]string{}
+			if tt.connectorID != "" {
+				pathParams["id"] = tt.connectorID
+			}
+			req := testutil.CreateRequestWithPathParams(
+				http.MethodPost,
+				"/connectors/"+tt.connectorID+"/sync",
+				pathParams,
+			)
+			recorder := httptest.NewRecorder()
+
+			handler.SyncConnector(recorder, req)
+
+			assert.Equal(t, tt.expectedStatus, recorder.Code)
+
+			if tt.expectedError != "" {
+				assert.Contains(t, recorder.Body.String(), tt.expectedError)
+			}
+
+			if tt.validateFunc != nil {
+				tt.validateFunc(t, recorder)
+			}
+
+			if tt.expectedStatus == http.StatusAccepted {
+				assert.Len(t, mockService.SyncConnectorCalls, 1)
+			}
+		})
+	}
+}

--- a/internal/adapter/inbound/api/routes.go
+++ b/internal/adapter/inbound/api/routes.go
@@ -98,6 +98,20 @@ func NewRouteRegistry() *RouteRegistry {
 	}
 }
 
+// RegisterConnectorRoutes registers all connector-related API routes.
+// The API is read-only; POST /connectors and DELETE /connectors/{id} are not registered.
+func (r *RouteRegistry) RegisterConnectorRoutes(connectorHandler *ConnectorHandler) {
+	if err := r.RegisterRoute("GET /connectors", http.HandlerFunc(connectorHandler.ListConnectors)); err != nil {
+		panic(fmt.Errorf("failed to register list connectors route: %w", err))
+	}
+	if err := r.RegisterRoute("GET /connectors/{id}", http.HandlerFunc(connectorHandler.GetConnector)); err != nil {
+		panic(fmt.Errorf("failed to register get connector route: %w", err))
+	}
+	if err := r.RegisterRoute("POST /connectors/{id}/sync", http.HandlerFunc(connectorHandler.SyncConnector)); err != nil {
+		panic(fmt.Errorf("failed to register sync connector route: %w", err))
+	}
+}
+
 // RegisterAPIRoutes registers all API routes with their handlers.
 func (r *RouteRegistry) RegisterAPIRoutes(healthHandler *HealthHandler, repositoryHandler *RepositoryHandler) {
 	// Health endpoint

--- a/internal/adapter/inbound/api/server.go
+++ b/internal/adapter/inbound/api/server.go
@@ -15,28 +15,30 @@ import (
 
 // Server represents the HTTP API server.
 type Server struct {
-	config          *config.Config
-	httpServer      *http.Server
-	routeRegistry   *RouteRegistry
-	healthService   inbound.HealthService
-	repoService     inbound.RepositoryService
-	searchService   inbound.SearchService
-	errorHandler    ErrorHandler
-	listener        net.Listener
-	isRunning       bool
-	mu              sync.RWMutex
-	middleware      map[string]bool
-	middlewareCount int
+	config           *config.Config
+	httpServer       *http.Server
+	routeRegistry    *RouteRegistry
+	healthService    inbound.HealthService
+	repoService      inbound.RepositoryService
+	searchService    inbound.SearchService
+	connectorService inbound.ConnectorService
+	errorHandler     ErrorHandler
+	listener         net.Listener
+	isRunning        bool
+	mu               sync.RWMutex
+	middleware       map[string]bool
+	middlewareCount  int
 }
 
 // ServerBuilder provides a fluent interface for building Server instances.
 type ServerBuilder struct {
-	config        *config.Config
-	healthService inbound.HealthService
-	repoService   inbound.RepositoryService
-	searchService inbound.SearchService
-	errorHandler  ErrorHandler
-	middleware    []MiddlewareFunc
+	config           *config.Config
+	healthService    inbound.HealthService
+	repoService      inbound.RepositoryService
+	searchService    inbound.SearchService
+	connectorService inbound.ConnectorService
+	errorHandler     ErrorHandler
+	middleware       []MiddlewareFunc
 }
 
 // MiddlewareFunc defines the middleware function signature.
@@ -65,6 +67,12 @@ func (b *ServerBuilder) WithRepositoryService(service inbound.RepositoryService)
 // WithSearchService sets the search service.
 func (b *ServerBuilder) WithSearchService(service inbound.SearchService) *ServerBuilder {
 	b.searchService = service
+	return b
+}
+
+// WithConnectorService sets the connector service.
+func (b *ServerBuilder) WithConnectorService(service inbound.ConnectorService) *ServerBuilder {
+	b.connectorService = service
 	return b
 }
 
@@ -144,6 +152,12 @@ func (b *ServerBuilder) buildServer() *Server {
 		}
 	}
 
+	// Register connector routes if connector service is provided
+	if b.connectorService != nil {
+		connectorHandler := NewConnectorHandler(b.connectorService, b.errorHandler)
+		registry.RegisterConnectorRoutes(connectorHandler)
+	}
+
 	// Build ServeMux
 	mux := registry.BuildServeMux()
 
@@ -169,15 +183,16 @@ func (b *ServerBuilder) buildServer() *Server {
 	httpServer := b.createHTTPServer(handler)
 
 	return &Server{
-		config:          b.config,
-		httpServer:      httpServer,
-		routeRegistry:   registry,
-		healthService:   b.healthService,
-		repoService:     b.repoService,
-		searchService:   b.searchService,
-		errorHandler:    b.errorHandler,
-		middleware:      middlewareMap,
-		middlewareCount: middlewareCount,
+		config:           b.config,
+		httpServer:       httpServer,
+		routeRegistry:    registry,
+		healthService:    b.healthService,
+		repoService:      b.repoService,
+		searchService:    b.searchService,
+		connectorService: b.connectorService,
+		errorHandler:     b.errorHandler,
+		middleware:       middlewareMap,
+		middlewareCount:  middlewareCount,
 	}
 }
 

--- a/internal/adapter/inbound/api/testutil/mocks.go
+++ b/internal/adapter/inbound/api/testutil/mocks.go
@@ -352,6 +352,12 @@ func (m *MockErrorHandler) HandleServiceError(w http.ResponseWriter, r *http.Req
 		http.Error(w, "service error", http.StatusConflict)
 	case errors.Is(err, domain.ErrJobNotFound):
 		http.Error(w, "service error", http.StatusNotFound)
+	case errors.Is(err, domain.ErrConnectorNotFound):
+		http.Error(w, "service error", http.StatusNotFound)
+	case errors.Is(err, domain.ErrConnectorAlreadyExists):
+		http.Error(w, "service error", http.StatusConflict)
+	case errors.Is(err, domain.ErrConnectorSyncing):
+		http.Error(w, "service error", http.StatusConflict)
 	default:
 		http.Error(w, "service error", http.StatusInternalServerError)
 	}

--- a/internal/adapter/inbound/service/connector_service_adapter.go
+++ b/internal/adapter/inbound/service/connector_service_adapter.go
@@ -1,0 +1,50 @@
+// Package service contains inbound service adapters.
+package service
+
+import (
+	"codechunking/internal/application/dto"
+	appservice "codechunking/internal/application/service"
+	"codechunking/internal/port/inbound"
+	"codechunking/internal/port/outbound"
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// ConnectorServiceAdapter adapts the application service layer to the inbound port.
+// It implements the inbound.ConnectorService interface by delegating to application services.
+type ConnectorServiceAdapter struct {
+	getSvc  *appservice.GetConnectorService
+	listSvc *appservice.ListConnectorsService
+	syncSvc *appservice.SyncConnectorService
+}
+
+// NewConnectorServiceAdapter creates a new ConnectorServiceAdapter.
+func NewConnectorServiceAdapter(connectorRepo outbound.ConnectorRepository) inbound.ConnectorService {
+	return &ConnectorServiceAdapter{
+		getSvc:  appservice.NewGetConnectorService(connectorRepo),
+		listSvc: appservice.NewListConnectorsService(connectorRepo),
+		syncSvc: appservice.NewSyncConnectorService(connectorRepo),
+	}
+}
+
+// GetConnector retrieves a connector by ID.
+func (a *ConnectorServiceAdapter) GetConnector(ctx context.Context, id uuid.UUID) (*dto.ConnectorResponse, error) {
+	return a.getSvc.GetConnector(ctx, id)
+}
+
+// ListConnectors returns a paginated list of connectors.
+func (a *ConnectorServiceAdapter) ListConnectors(
+	ctx context.Context,
+	query dto.ConnectorListQuery,
+) (*dto.ConnectorListResponse, error) {
+	return a.listSvc.ListConnectors(ctx, query)
+}
+
+// SyncConnector triggers a sync for a connector.
+func (a *ConnectorServiceAdapter) SyncConnector(
+	ctx context.Context,
+	id uuid.UUID,
+) (*dto.SyncConnectorResponse, error) {
+	return a.syncSvc.SyncConnector(ctx, id)
+}

--- a/internal/adapter/outbound/gitprovider/gitlab_provider.go
+++ b/internal/adapter/outbound/gitprovider/gitlab_provider.go
@@ -1,0 +1,208 @@
+package gitprovider
+
+import (
+	"codechunking/internal/domain/entity"
+	"codechunking/internal/port/outbound"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// GitLabProvider implements outbound.GitProvider for GitLab instances.
+type GitLabProvider struct {
+	httpClient *http.Client
+}
+
+// NewGitLabProvider creates a new GitLabProvider.
+func NewGitLabProvider(httpClient *http.Client) *GitLabProvider {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 30 * time.Second}
+	}
+	return &GitLabProvider{httpClient: httpClient}
+}
+
+// ListRepositories calls the GitLab API to list projects from all configured groups
+// and individual projects defined on the connector.
+// Results are deduplicated by HTTP clone URL.
+func (p *GitLabProvider) ListRepositories(
+	ctx context.Context,
+	connector *entity.Connector,
+) ([]outbound.GitProviderRepository, error) {
+	baseURL := connector.BaseURL()
+	if baseURL == "" {
+		baseURL = "https://gitlab.com"
+	}
+
+	seen := make(map[string]struct{})
+	var result []outbound.GitProviderRepository
+
+	// List projects from each group.
+	for _, group := range connector.Groups() {
+		repos, err := p.listGroupProjects(ctx, baseURL, group, connector.AuthToken())
+		if err != nil {
+			return nil, fmt.Errorf("listing group %q: %w", group, err)
+		}
+		for _, repo := range repos {
+			if _, dup := seen[repo.URL]; dup {
+				continue
+			}
+			seen[repo.URL] = struct{}{}
+			result = append(result, repo)
+		}
+	}
+
+	// Fetch individually specified projects.
+	for _, project := range connector.Projects() {
+		repo, err := p.getProject(ctx, baseURL, project, connector.AuthToken())
+		if err != nil {
+			return nil, fmt.Errorf("fetching project %q: %w", project, err)
+		}
+		if _, dup := seen[repo.URL]; dup {
+			continue
+		}
+		seen[repo.URL] = struct{}{}
+		result = append(result, *repo)
+	}
+
+	return result, nil
+}
+
+// listGroupProjects calls GET /groups/{id}/projects and pages through all results.
+func (p *GitLabProvider) listGroupProjects(
+	ctx context.Context,
+	baseURL, groupPath string,
+	authToken *string,
+) ([]outbound.GitProviderRepository, error) {
+	// url.PathEscape intentionally leaves '/' unencoded (valid in path segments),
+	// but GitLab treats the entire group path as a single opaque ID, so slashes
+	// must be percent-encoded as %2F to avoid being interpreted as path separators.
+	groupID := strings.ReplaceAll(url.PathEscape(groupPath), "/", "%2F")
+	page := 1
+	var result []outbound.GitProviderRepository
+
+	for {
+		apiURL := fmt.Sprintf("%s/api/v4/groups/%s/projects?per_page=100&include_subgroups=true&page=%d", baseURL, groupID, page)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("build list-group-projects request: %w", err)
+		}
+		setAuthHeader(req, authToken)
+
+		resp, err := p.httpClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("list-group-projects request: %w", err)
+		}
+
+		if err := checkHTTPStatus(resp, "gitlab list group projects"); err != nil {
+			_ = resp.Body.Close()
+			return nil, err
+		}
+
+		var projects []gitlabProject
+		decodeErr := json.NewDecoder(resp.Body).Decode(&projects)
+		_ = resp.Body.Close()
+		if decodeErr != nil {
+			return nil, fmt.Errorf("decode gitlab projects response: %w", decodeErr)
+		}
+
+		for _, proj := range projects {
+			result = append(result, gitlabProjectToRepo(proj))
+		}
+
+		nextPage := resp.Header.Get("X-Next-Page")
+		if nextPage == "" {
+			break
+		}
+		page++
+	}
+
+	return result, nil
+}
+
+// getProject calls GET /projects/{id} (id may be URL-encoded namespace/project).
+func (p *GitLabProvider) getProject(
+	ctx context.Context,
+	baseURL, projectPath string,
+	authToken *string,
+) (*outbound.GitProviderRepository, error) {
+	projectID := url.PathEscape(projectPath)
+	apiURL := fmt.Sprintf("%s/api/v4/projects/%s", baseURL, projectID)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build get-project request: %w", err)
+	}
+	setAuthHeader(req, authToken)
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("get-project request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if err := checkHTTPStatus(resp, "gitlab get project"); err != nil {
+		return nil, err
+	}
+
+	var project gitlabProject
+	if err := json.NewDecoder(resp.Body).Decode(&project); err != nil {
+		return nil, fmt.Errorf("decode gitlab project response: %w", err)
+	}
+
+	repo := gitlabProjectToRepo(project)
+	return &repo, nil
+}
+
+// ValidateCredentials verifies the token by calling the /user endpoint.
+func (p *GitLabProvider) ValidateCredentials(ctx context.Context, connector *entity.Connector) error {
+	baseURL := connector.BaseURL()
+	if baseURL == "" {
+		baseURL = "https://gitlab.com"
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/api/v4/user", nil)
+	if err != nil {
+		return fmt.Errorf("build gitlab validate request: %w", err)
+	}
+	setAuthHeader(req, connector.AuthToken())
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("gitlab validate request: %w", err)
+	}
+	defer resp.Body.Close()
+	return checkHTTPStatus(resp, "gitlab validate credentials")
+}
+
+// setAuthHeader sets the Private-Token header when a non-empty token is provided.
+func setAuthHeader(req *http.Request, authToken *string) {
+	if authToken != nil && *authToken != "" {
+		req.Header.Set("Private-Token", *authToken)
+	}
+}
+
+// gitlabProjectToRepo converts a GitLab API project to a GitProviderRepository.
+func gitlabProjectToRepo(p gitlabProject) outbound.GitProviderRepository {
+	return outbound.GitProviderRepository{
+		Name:          p.Name,
+		URL:           p.HTTPURLToRepo,
+		Description:   p.Description,
+		DefaultBranch: p.DefaultBranch,
+		IsPrivate:     p.Visibility != "public",
+		LastActivity:  p.LastActivityAt,
+	}
+}
+
+type gitlabProject struct {
+	Name           string     `json:"name"`
+	HTTPURLToRepo  string     `json:"http_url_to_repo"`
+	Description    string     `json:"description"`
+	DefaultBranch  string     `json:"default_branch"`
+	Visibility     string     `json:"visibility"`
+	LastActivityAt *time.Time `json:"last_activity_at"`
+}

--- a/internal/adapter/outbound/gitprovider/gitlab_provider_test.go
+++ b/internal/adapter/outbound/gitprovider/gitlab_provider_test.go
@@ -1,0 +1,580 @@
+package gitprovider
+
+import (
+	"codechunking/internal/domain/entity"
+	"codechunking/internal/domain/valueobject"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestConnector builds a minimal Connector pointed at the given base URL with an optional auth token.
+func newTestConnector(t *testing.T, baseURL string, authToken *string, groups []string) *entity.Connector {
+	t.Helper()
+	connector, err := entity.NewConnector(
+		"test-connector",
+		valueobject.ConnectorTypeGitLab,
+		baseURL,
+		authToken,
+		groups,
+		nil,
+	)
+	require.NoError(t, err)
+	return connector
+}
+
+// mustToken is a convenience that returns a pointer to the given token string.
+func mustToken(s string) *string { return &s }
+
+// encodeJSON serialises v to JSON and fails the test on error.
+func encodeJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return b
+}
+
+// ---- helpers for building stub GitLab API project payloads ----
+
+type stubProject struct {
+	Name           string     `json:"name"`
+	HTTPURLToRepo  string     `json:"http_url_to_repo"`
+	Description    string     `json:"description"`
+	DefaultBranch  string     `json:"default_branch"`
+	Visibility     string     `json:"visibility"`
+	LastActivityAt *time.Time `json:"last_activity_at"`
+}
+
+func publicProject(name, cloneURL string) stubProject {
+	return stubProject{
+		Name:          name,
+		HTTPURLToRepo: cloneURL,
+		Description:   name + " description",
+		DefaultBranch: "main",
+		Visibility:    "public",
+	}
+}
+
+func privateProject(name, cloneURL string) stubProject {
+	return stubProject{
+		Name:          name,
+		HTTPURLToRepo: cloneURL,
+		Description:   name + " description",
+		DefaultBranch: "main",
+		Visibility:    "private",
+	}
+}
+
+// ---- tests for listGroupProjects via ListRepositories ----
+
+// TestListGroupProjects_SinglePage verifies that when the GitLab API returns a single
+// page of projects (no X-Next-Page header), all projects on that page are returned and
+// mapped to GitProviderRepository with correct field values.
+func TestListGroupProjects_SinglePage(t *testing.T) {
+	projects := []stubProject{
+		publicProject("repo-alpha", "https://gitlab.example.com/my-group/repo-alpha.git"),
+		privateProject("repo-beta", "https://gitlab.example.com/my-group/repo-beta.git"),
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Deliberately omit X-Next-Page to signal a single page.
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(encodeJSON(t, projects))
+	}))
+	defer srv.Close()
+
+	provider := NewGitLabProvider(srv.Client())
+	connector := newTestConnector(t, srv.URL, nil, []string{"my-group"})
+
+	got, err := provider.ListRepositories(context.Background(), connector)
+
+	require.NoError(t, err)
+	require.Len(t, got, 2, "expected exactly two repositories from a single-page response")
+
+	assert.Equal(t, "repo-alpha", got[0].Name)
+	assert.Equal(t, "https://gitlab.example.com/my-group/repo-alpha.git", got[0].URL)
+	assert.Equal(t, "repo-alpha description", got[0].Description)
+	assert.Equal(t, "main", got[0].DefaultBranch)
+	assert.False(t, got[0].IsPrivate, "public project must not be flagged as private")
+
+	assert.Equal(t, "repo-beta", got[1].Name)
+	assert.Equal(t, "https://gitlab.example.com/my-group/repo-beta.git", got[1].URL)
+	assert.True(t, got[1].IsPrivate, "private project must be flagged as private")
+}
+
+// TestListGroupProjects_MultiplePages verifies that when the first response carries an
+// X-Next-Page header the provider fetches subsequent pages and returns the combined set.
+func TestListGroupProjects_MultiplePages(t *testing.T) {
+	page1 := []stubProject{
+		publicProject("repo-page1-a", "https://gitlab.example.com/grp/repo-page1-a.git"),
+		publicProject("repo-page1-b", "https://gitlab.example.com/grp/repo-page1-b.git"),
+	}
+	page2 := []stubProject{
+		publicProject("repo-page2-a", "https://gitlab.example.com/grp/repo-page2-a.git"),
+	}
+
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		switch callCount {
+		case 1:
+			// First page: signal that page 2 exists.
+			w.Header().Set("X-Next-Page", "2")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(encodeJSON(t, page1))
+		default:
+			// Second (and last) page: no X-Next-Page header.
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(encodeJSON(t, page2))
+		}
+	}))
+	defer srv.Close()
+
+	provider := NewGitLabProvider(srv.Client())
+	connector := newTestConnector(t, srv.URL, nil, []string{"grp"})
+
+	got, err := provider.ListRepositories(context.Background(), connector)
+
+	require.NoError(t, err)
+	require.Len(t, got, 3, "all three projects across both pages must be returned")
+	assert.Equal(t, 2, callCount, "provider must issue exactly two HTTP requests for two pages")
+
+	names := make([]string, len(got))
+	for i, r := range got {
+		names[i] = r.Name
+	}
+	assert.Contains(t, names, "repo-page1-a")
+	assert.Contains(t, names, "repo-page1-b")
+	assert.Contains(t, names, "repo-page2-a")
+}
+
+// TestListGroupProjects_ThreePages verifies pagination across more than two pages so
+// that the loop termination is driven solely by an empty X-Next-Page, not a counter.
+func TestListGroupProjects_ThreePages(t *testing.T) {
+	pages := [][]stubProject{
+		{publicProject("p1", "https://gitlab.example.com/g/p1.git")},
+		{publicProject("p2", "https://gitlab.example.com/g/p2.git")},
+		{publicProject("p3", "https://gitlab.example.com/g/p3.git")},
+	}
+
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		idx := callCount
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		if idx < len(pages)-1 {
+			w.Header().Set("X-Next-Page", "next")
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(encodeJSON(t, pages[idx]))
+	}))
+	defer srv.Close()
+
+	provider := NewGitLabProvider(srv.Client())
+	connector := newTestConnector(t, srv.URL, nil, []string{"g"})
+
+	got, err := provider.ListRepositories(context.Background(), connector)
+
+	require.NoError(t, err)
+	assert.Len(t, got, 3)
+	assert.Equal(t, 3, callCount, "provider must issue one request per page")
+}
+
+// TestListGroupProjects_HTTPErrorReturnsError verifies that a non-2xx response (e.g. 401
+// Unauthorized) causes ListRepositories to propagate an error rather than return repos.
+func TestListGroupProjects_HTTPErrorReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"401 Unauthorized"}`))
+	}))
+	defer srv.Close()
+
+	provider := NewGitLabProvider(srv.Client())
+	connector := newTestConnector(t, srv.URL, nil, []string{"my-group"})
+
+	got, err := provider.ListRepositories(context.Background(), connector)
+
+	require.Error(t, err, "a 401 response must produce an error")
+	assert.Nil(t, got, "no repositories must be returned on error")
+}
+
+// TestListGroupProjects_ForbiddenReturnsError verifies that a 403 response is treated
+// as an error, distinguishing it from the 401 case.
+func TestListGroupProjects_ForbiddenReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"403 Forbidden"}`))
+	}))
+	defer srv.Close()
+
+	provider := NewGitLabProvider(srv.Client())
+	connector := newTestConnector(t, srv.URL, nil, []string{"restricted-group"})
+
+	_, err := provider.ListRepositories(context.Background(), connector)
+
+	require.Error(t, err, "a 403 response must produce an error")
+}
+
+// TestListGroupProjects_InvalidJSONReturnsError verifies that a 200 OK response whose
+// body is not valid JSON causes ListRepositories to return an error.
+func TestListGroupProjects_InvalidJSONReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`not valid json [`))
+	}))
+	defer srv.Close()
+
+	provider := NewGitLabProvider(srv.Client())
+	connector := newTestConnector(t, srv.URL, nil, []string{"my-group"})
+
+	got, err := provider.ListRepositories(context.Background(), connector)
+
+	require.Error(t, err, "malformed JSON in the response body must produce an error")
+	assert.Nil(t, got)
+}
+
+// TestListGroupProjects_AuthTokenForwardedAsPrivateToken verifies that when a connector
+// carries an auth token the provider sets the Private-Token request header on every
+// request it makes to the GitLab API.
+func TestListGroupProjects_AuthTokenForwardedAsPrivateToken(t *testing.T) {
+	const expectedToken = "glpat-super-secret-token"
+	receivedTokens := []string{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedTokens = append(receivedTokens, r.Header.Get("Private-Token"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(encodeJSON(t, []stubProject{
+			publicProject("secured-repo", "https://gitlab.example.com/grp/secured-repo.git"),
+		}))
+	}))
+	defer srv.Close()
+
+	provider := NewGitLabProvider(srv.Client())
+	connector := newTestConnector(t, srv.URL, mustToken(expectedToken), []string{"grp"})
+
+	_, err := provider.ListRepositories(context.Background(), connector)
+
+	require.NoError(t, err)
+	require.NotEmpty(t, receivedTokens, "at least one request must have been made")
+	for i, tok := range receivedTokens {
+		assert.Equal(t, expectedToken, tok,
+			"request %d must carry the correct Private-Token header", i+1)
+	}
+}
+
+// TestListGroupProjects_AuthTokenForwardedOnEveryPage verifies that the Private-Token
+// header is sent on all paginated requests, not just the first.
+func TestListGroupProjects_AuthTokenForwardedOnEveryPage(t *testing.T) {
+	const expectedToken = "glpat-multi-page-token"
+	receivedTokens := []string{}
+
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		receivedTokens = append(receivedTokens, r.Header.Get("Private-Token"))
+		w.Header().Set("Content-Type", "application/json")
+		if callCount == 1 {
+			w.Header().Set("X-Next-Page", "2")
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(encodeJSON(t, []stubProject{
+			publicProject("repo", "https://gitlab.example.com/grp/repo.git"),
+		}))
+	}))
+	defer srv.Close()
+
+	provider := NewGitLabProvider(srv.Client())
+	connector := newTestConnector(t, srv.URL, mustToken(expectedToken), []string{"grp"})
+
+	_, err := provider.ListRepositories(context.Background(), connector)
+
+	require.NoError(t, err)
+	require.Len(t, receivedTokens, 2, "expected two requests (one per page)")
+	assert.Equal(t, expectedToken, receivedTokens[0], "page 1 request must carry Private-Token")
+	assert.Equal(t, expectedToken, receivedTokens[1], "page 2 request must carry Private-Token")
+}
+
+// TestListGroupProjects_NoAuthTokenOmitsPrivateTokenHeader verifies that when the
+// connector has no auth token the Private-Token header is absent from requests.
+func TestListGroupProjects_NoAuthTokenOmitsPrivateTokenHeader(t *testing.T) {
+	var capturedToken string
+	var tokenHeaderPresent bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedToken = r.Header.Get("Private-Token")
+		_, tokenHeaderPresent = r.Header["Private-Token"]
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(encodeJSON(t, []stubProject{}))
+	}))
+	defer srv.Close()
+
+	provider := NewGitLabProvider(srv.Client())
+	connector := newTestConnector(t, srv.URL, nil, []string{"public-group"})
+
+	_, err := provider.ListRepositories(context.Background(), connector)
+
+	require.NoError(t, err)
+	assert.False(t, tokenHeaderPresent,
+		"Private-Token header must be absent when no auth token is configured; got %q", capturedToken)
+}
+
+// TestListGroupProjects_EmptyGroupReturnsEmptySlice verifies that a 200 OK with an
+// empty JSON array yields an empty (not nil) result without error.
+func TestListGroupProjects_EmptyGroupReturnsEmptySlice(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer srv.Close()
+
+	provider := NewGitLabProvider(srv.Client())
+	connector := newTestConnector(t, srv.URL, nil, []string{"empty-group"})
+
+	got, err := provider.ListRepositories(context.Background(), connector)
+
+	require.NoError(t, err)
+	assert.Empty(t, got, "an empty projects list must yield no repositories")
+}
+
+// TestListGroupProjects_IsPrivateMapping verifies that the IsPrivate field is derived
+// solely from the visibility field: only "public" visibility results in IsPrivate=false;
+// any other value (private, internal) maps to IsPrivate=true.
+func TestListGroupProjects_IsPrivateMapping(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	projects := []stubProject{
+		{Name: "pub", HTTPURLToRepo: "https://gl.example.com/g/pub.git", Visibility: "public", DefaultBranch: "main"},
+		{Name: "priv", HTTPURLToRepo: "https://gl.example.com/g/priv.git", Visibility: "private", DefaultBranch: "main"},
+		{Name: "internal", HTTPURLToRepo: "https://gl.example.com/g/internal.git", Visibility: "internal", DefaultBranch: "main"},
+		{Name: "with-activity", HTTPURLToRepo: "https://gl.example.com/g/act.git", Visibility: "public", DefaultBranch: "develop", LastActivityAt: &now},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(encodeJSON(t, projects))
+	}))
+	defer srv.Close()
+
+	provider := NewGitLabProvider(srv.Client())
+	connector := newTestConnector(t, srv.URL, nil, []string{"g"})
+
+	got, err := provider.ListRepositories(context.Background(), connector)
+
+	require.NoError(t, err)
+	require.Len(t, got, 4)
+
+	byName := make(map[string]bool, len(got))
+	for _, r := range got {
+		byName[r.Name] = r.IsPrivate
+	}
+
+	assert.False(t, byName["pub"], "public visibility must map to IsPrivate=false")
+	assert.True(t, byName["priv"], "private visibility must map to IsPrivate=true")
+	assert.True(t, byName["internal"], "internal visibility must map to IsPrivate=true")
+
+	// Also verify LastActivity is propagated correctly.
+	for _, r := range got {
+		if r.Name == "with-activity" {
+			require.NotNil(t, r.LastActivity)
+			assert.Equal(t, now, r.LastActivity.UTC().Truncate(time.Second))
+		}
+	}
+}
+
+// TestListGroupProjects_PaginationRequestsCorrectPageQueryParam verifies that the
+// provider increments the page query parameter on each request so the API can return
+// distinct pages.
+func TestListGroupProjects_PaginationRequestsCorrectPageQueryParam(t *testing.T) {
+	receivedPages := []string{}
+
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPages = append(receivedPages, r.URL.Query().Get("page"))
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		if callCount == 1 {
+			w.Header().Set("X-Next-Page", "2")
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(encodeJSON(t, []stubProject{
+			publicProject("r", "https://gl.example.com/g/r.git"),
+		}))
+	}))
+	defer srv.Close()
+
+	provider := NewGitLabProvider(srv.Client())
+	connector := newTestConnector(t, srv.URL, nil, []string{"g"})
+
+	_, err := provider.ListRepositories(context.Background(), connector)
+
+	require.NoError(t, err)
+	require.Len(t, receivedPages, 2)
+	assert.Equal(t, "1", receivedPages[0], "first request must use page=1")
+	assert.Equal(t, "2", receivedPages[1], "second request must use page=2")
+}
+
+// TestListGroupProjects_PaginationRequestsPerPage100 verifies that every request
+// uses per_page=100 as required by the API contract.
+func TestListGroupProjects_PaginationRequestsPerPage100(t *testing.T) {
+	receivedPerPage := []string{}
+
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPerPage = append(receivedPerPage, r.URL.Query().Get("per_page"))
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		if callCount == 1 {
+			w.Header().Set("X-Next-Page", "2")
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(encodeJSON(t, []stubProject{
+			publicProject("r", "https://gl.example.com/g/r.git"),
+		}))
+	}))
+	defer srv.Close()
+
+	provider := NewGitLabProvider(srv.Client())
+	connector := newTestConnector(t, srv.URL, nil, []string{"g"})
+
+	_, err := provider.ListRepositories(context.Background(), connector)
+
+	require.NoError(t, err)
+	for i, pp := range receivedPerPage {
+		assert.Equal(t, "100", pp, "request %d must use per_page=100", i+1)
+	}
+}
+
+// TestListGroupProjects_PaginationRequestsIncludeSubgroups verifies that every request
+// includes include_subgroups=true in the query string.
+func TestListGroupProjects_PaginationRequestsIncludeSubgroups(t *testing.T) {
+	receivedIncludeSubgroups := []string{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedIncludeSubgroups = append(receivedIncludeSubgroups, r.URL.Query().Get("include_subgroups"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(encodeJSON(t, []stubProject{}))
+	}))
+	defer srv.Close()
+
+	provider := NewGitLabProvider(srv.Client())
+	connector := newTestConnector(t, srv.URL, nil, []string{"g"})
+
+	_, err := provider.ListRepositories(context.Background(), connector)
+
+	require.NoError(t, err)
+	require.NotEmpty(t, receivedIncludeSubgroups)
+	for i, val := range receivedIncludeSubgroups {
+		assert.Equal(t, "true", val, "request %d must include include_subgroups=true", i+1)
+	}
+}
+
+// TestListGroupProjects_ContextCancellationReturnsError verifies that when the context
+// is already cancelled before the call the provider surfaces an error rather than
+// hanging or returning stale data.
+func TestListGroupProjects_ContextCancellationReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(encodeJSON(t, []stubProject{}))
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately before making the call
+
+	provider := NewGitLabProvider(srv.Client())
+	connector := newTestConnector(t, srv.URL, nil, []string{"g"})
+
+	_, err := provider.ListRepositories(ctx, connector)
+
+	require.Error(t, err, "a pre-cancelled context must produce an error")
+}
+
+// TestListGroupProjects_GroupPathIsURLEncoded verifies that a group path containing a
+// slash (namespace/subgroup) is percent-encoded in the request URL so that GitLab
+// identifies it as a single path-escaped ID.
+func TestListGroupProjects_GroupPathIsURLEncoded(t *testing.T) {
+	receivedURIs := []string{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// r.RequestURI preserves raw percent-encoding; r.URL.Path is always decoded by Go's HTTP server.
+		receivedURIs = append(receivedURIs, r.RequestURI)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(encodeJSON(t, []stubProject{}))
+	}))
+	defer srv.Close()
+
+	provider := NewGitLabProvider(srv.Client())
+	connector := newTestConnector(t, srv.URL, nil, []string{"my-namespace/my-subgroup"})
+
+	_, err := provider.ListRepositories(context.Background(), connector)
+
+	require.NoError(t, err)
+	require.NotEmpty(t, receivedURIs)
+	// The group path slash must be percent-encoded as %2F in the URL path segment.
+	assert.Contains(t, receivedURIs[0], "my-namespace%2Fmy-subgroup",
+		"group path with slash must be URL-encoded in the request path; got %s", receivedURIs[0])
+}
+
+// TestListGroupProjects_MultipleGroupsAggregated verifies that when a connector has
+// multiple groups, repositories from each group are all returned in a single result set.
+func TestListGroupProjects_MultipleGroupsAggregated(t *testing.T) {
+	groupResponses := map[string][]stubProject{
+		"group-a": {publicProject("a1", "https://gl.example.com/group-a/a1.git")},
+		"group-b": {publicProject("b1", "https://gl.example.com/group-b/b1.git")},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if contains(r.URL.Path, "group-a") {
+			_, _ = w.Write(encodeJSON(t, groupResponses["group-a"]))
+		} else {
+			_, _ = w.Write(encodeJSON(t, groupResponses["group-b"]))
+		}
+	}))
+	defer srv.Close()
+
+	provider := NewGitLabProvider(srv.Client())
+	connector := newTestConnector(t, srv.URL, nil, []string{"group-a", "group-b"})
+
+	got, err := provider.ListRepositories(context.Background(), connector)
+
+	require.NoError(t, err)
+	assert.Len(t, got, 2, "repos from both groups must be combined into a single result")
+
+	names := make([]string, len(got))
+	for i, r := range got {
+		names[i] = r.Name
+	}
+	assert.Contains(t, names, "a1")
+	assert.Contains(t, names, "b1")
+}
+
+// contains is a simple substring check used as a routing aid in test handlers.
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && stringContains(s, substr))
+}
+
+func stringContains(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/adapter/outbound/gitprovider/http_helpers.go
+++ b/internal/adapter/outbound/gitprovider/http_helpers.go
@@ -1,0 +1,15 @@
+package gitprovider
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
+
+func checkHTTPStatus(resp *http.Response, operation string) error {
+	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
+		return nil
+	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+	return fmt.Errorf("%s: unexpected status %d: %s", operation, resp.StatusCode, string(body))
+}

--- a/internal/adapter/outbound/repository/connector_repository.go
+++ b/internal/adapter/outbound/repository/connector_repository.go
@@ -1,0 +1,371 @@
+package repository
+
+import (
+	"codechunking/internal/domain/entity"
+	domainerrors "codechunking/internal/domain/errors/domain"
+	"codechunking/internal/domain/valueobject"
+	"codechunking/internal/port/outbound"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// PostgreSQLConnectorRepository implements the ConnectorRepository interface.
+type PostgreSQLConnectorRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewPostgreSQLConnectorRepository creates a new PostgreSQL connector repository.
+func NewPostgreSQLConnectorRepository(pool *pgxpool.Pool) *PostgreSQLConnectorRepository {
+	return &PostgreSQLConnectorRepository{pool: pool}
+}
+
+// Save inserts a new connector record into the database.
+func (r *PostgreSQLConnectorRepository) Save(ctx context.Context, connector *entity.Connector) error {
+	if connector == nil {
+		return ErrInvalidArgument
+	}
+
+	groupsJSON, err := json.Marshal(connector.Groups())
+	if err != nil {
+		return fmt.Errorf("marshal connector groups: %w", err)
+	}
+	projectsJSON, err := json.Marshal(connector.Projects())
+	if err != nil {
+		return fmt.Errorf("marshal connector projects: %w", err)
+	}
+
+	query := `
+		INSERT INTO codechunking.connectors (
+			id, name, connector_type, base_url, auth_token,
+			status, repository_count, last_sync_at, created_at, updated_at,
+			groups, projects
+		) VALUES (
+			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
+			$11::jsonb, $12::jsonb
+		)`
+
+	qi := GetQueryInterface(ctx, r.pool)
+	_, err = qi.Exec(ctx, query,
+		connector.ID(),
+		connector.Name(),
+		connector.ConnectorType().String(),
+		connector.BaseURL(),
+		connector.AuthToken(),
+		connector.Status().String(),
+		connector.RepositoryCount(),
+		connector.LastSyncAt(),
+		connector.CreatedAt(),
+		connector.UpdatedAt(),
+		string(groupsJSON),
+		string(projectsJSON),
+	)
+	if err != nil {
+		return WrapError(err, "save connector")
+	}
+	return nil
+}
+
+// FindByID retrieves a connector by its UUID.
+func (r *PostgreSQLConnectorRepository) FindByID(ctx context.Context, id uuid.UUID) (*entity.Connector, error) {
+	query := `
+		SELECT id, name, connector_type, base_url, auth_token,
+		       status, repository_count, last_sync_at, created_at, updated_at,
+		       groups, projects
+		FROM codechunking.connectors
+		WHERE id = $1`
+
+	qi := GetQueryInterface(ctx, r.pool)
+	row := qi.QueryRow(ctx, query, id)
+
+	connector, err := scanConnector(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, domainerrors.ErrConnectorNotFound
+		}
+		return nil, WrapError(err, "find connector by id")
+	}
+	return connector, nil
+}
+
+// FindByName retrieves a connector by its unique name.
+func (r *PostgreSQLConnectorRepository) FindByName(ctx context.Context, name string) (*entity.Connector, error) {
+	query := `
+		SELECT id, name, connector_type, base_url, auth_token,
+		       status, repository_count, last_sync_at, created_at, updated_at,
+		       groups, projects
+		FROM codechunking.connectors
+		WHERE name = $1`
+
+	qi := GetQueryInterface(ctx, r.pool)
+	row := qi.QueryRow(ctx, query, name)
+
+	connector, err := scanConnector(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, domainerrors.ErrConnectorNotFound
+		}
+		return nil, WrapError(err, "find connector by name")
+	}
+	return connector, nil
+}
+
+// FindAll returns a paginated list of connectors matching the given filters.
+func (r *PostgreSQLConnectorRepository) FindAll(
+	ctx context.Context,
+	filters outbound.ConnectorFilters,
+) ([]*entity.Connector, int, error) {
+	baseSelect := `
+		SELECT id, name, connector_type, base_url, auth_token,
+		       status, repository_count, last_sync_at, created_at, updated_at,
+		       groups, projects
+		FROM codechunking.connectors`
+	baseCount := `SELECT COUNT(*) FROM codechunking.connectors`
+
+	conditions, args := buildConnectorFilterConditions(filters)
+	where := ""
+	if len(conditions) > 0 {
+		where = " WHERE " + strings.Join(conditions, " AND ")
+	}
+
+	// Count query
+	var total int
+	qi := GetQueryInterface(ctx, r.pool)
+	if err := qi.QueryRow(ctx, baseCount+where, args...).Scan(&total); err != nil {
+		return nil, 0, WrapError(err, "count connectors")
+	}
+
+	// Data query
+	orderBy := buildConnectorOrderBy(filters.Sort)
+	limit := filters.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+	offset := filters.Offset
+	if offset < 0 {
+		offset = 0
+	}
+
+	dataQuery := fmt.Sprintf(
+		"%s%s%s LIMIT $%d OFFSET $%d",
+		baseSelect, where, orderBy, len(args)+1, len(args)+2,
+	)
+	args = append(args, limit, offset)
+
+	rows, err := qi.Query(ctx, dataQuery, args...)
+	if err != nil {
+		return nil, 0, WrapError(err, "list connectors")
+	}
+	defer rows.Close()
+
+	var connectors []*entity.Connector
+	for rows.Next() {
+		connector, err := scanConnector(rows)
+		if err != nil {
+			return nil, 0, WrapError(err, "scan connector row")
+		}
+		connectors = append(connectors, connector)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, WrapError(err, "iterate connector rows")
+	}
+
+	return connectors, total, nil
+}
+
+// Update persists changes to an existing connector.
+func (r *PostgreSQLConnectorRepository) Update(ctx context.Context, connector *entity.Connector) error {
+	if connector == nil {
+		return ErrInvalidArgument
+	}
+
+	groupsJSON, err := json.Marshal(connector.Groups())
+	if err != nil {
+		return fmt.Errorf("marshal connector groups: %w", err)
+	}
+	projectsJSON, err := json.Marshal(connector.Projects())
+	if err != nil {
+		return fmt.Errorf("marshal connector projects: %w", err)
+	}
+
+	query := `
+		UPDATE codechunking.connectors
+		SET name             = $1,
+		    connector_type   = $2,
+		    base_url         = $3,
+		    auth_token       = $4,
+		    status           = $5,
+		    repository_count = $6,
+		    last_sync_at     = $7,
+		    updated_at       = $8,
+		    groups           = $9::jsonb,
+		    projects         = $10::jsonb
+		WHERE id = $11`
+
+	qi := GetQueryInterface(ctx, r.pool)
+	result, err := qi.Exec(ctx, query,
+		connector.Name(),
+		connector.ConnectorType().String(),
+		connector.BaseURL(),
+		connector.AuthToken(),
+		connector.Status().String(),
+		connector.RepositoryCount(),
+		connector.LastSyncAt(),
+		connector.UpdatedAt(),
+		string(groupsJSON),
+		string(projectsJSON),
+		connector.ID(),
+	)
+	if err != nil {
+		return WrapError(err, "update connector")
+	}
+	if result.RowsAffected() == 0 {
+		return domainerrors.ErrConnectorNotFound
+	}
+	return nil
+}
+
+// Delete removes a connector by its UUID.
+func (r *PostgreSQLConnectorRepository) Delete(ctx context.Context, id uuid.UUID) error {
+	query := `DELETE FROM codechunking.connectors WHERE id = $1`
+	qi := GetQueryInterface(ctx, r.pool)
+	result, err := qi.Exec(ctx, query, id)
+	if err != nil {
+		return WrapError(err, "delete connector")
+	}
+	if result.RowsAffected() == 0 {
+		return domainerrors.ErrConnectorNotFound
+	}
+	return nil
+}
+
+// Exists returns true when a connector with the given name already exists.
+func (r *PostgreSQLConnectorRepository) Exists(ctx context.Context, name string) (bool, error) {
+	query := `SELECT EXISTS(SELECT 1 FROM codechunking.connectors WHERE name = $1)`
+	qi := GetQueryInterface(ctx, r.pool)
+	var exists bool
+	if err := qi.QueryRow(ctx, query, name).Scan(&exists); err != nil {
+		return false, WrapError(err, "check connector existence")
+	}
+	return exists, nil
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+// rowScanner is satisfied by both pgx.Row and pgx.Rows so that scanConnector
+// can be used in both FindByID/FindByName (single row) and FindAll (multi row).
+type rowScanner interface {
+	Scan(dest ...interface{}) error
+}
+
+func scanConnector(row rowScanner) (*entity.Connector, error) {
+	var (
+		id              uuid.UUID
+		name            string
+		connectorType   string
+		baseURL         string
+		authToken       *string
+		status          string
+		repositoryCount int
+		lastSyncAt      *time.Time
+		createdAt       time.Time
+		updatedAt       time.Time
+		groupsJSON      []byte
+		projectsJSON    []byte
+	)
+
+	if err := row.Scan(
+		&id, &name, &connectorType, &baseURL, &authToken,
+		&status, &repositoryCount, &lastSyncAt, &createdAt, &updatedAt,
+		&groupsJSON, &projectsJSON,
+	); err != nil {
+		return nil, err
+	}
+
+	var groups []string
+	if len(groupsJSON) > 0 {
+		if err := json.Unmarshal(groupsJSON, &groups); err != nil {
+			groups = []string{}
+		}
+	}
+
+	var projects []string
+	if len(projectsJSON) > 0 {
+		if err := json.Unmarshal(projectsJSON, &projects); err != nil {
+			projects = []string{}
+		}
+	}
+
+	return buildConnectorEntity(
+		id, name, connectorType, baseURL, authToken,
+		status, repositoryCount, lastSyncAt, createdAt, updatedAt,
+		groups, projects,
+	)
+}
+
+func buildConnectorEntity(
+	id uuid.UUID,
+	name, connectorType, baseURL string,
+	authToken *string,
+	status string,
+	repositoryCount int,
+	lastSyncAt *time.Time,
+	createdAt, updatedAt time.Time,
+	groups, projects []string,
+) (*entity.Connector, error) {
+	ct, err := valueobject.NewConnectorType(connectorType)
+	if err != nil {
+		return nil, fmt.Errorf("invalid connector type in database: %w", err)
+	}
+	cs, err := valueobject.NewConnectorStatus(status)
+	if err != nil {
+		return nil, fmt.Errorf("invalid connector status in database: %w", err)
+	}
+	return entity.RestoreConnector(
+		id, name, ct, baseURL, authToken, cs, repositoryCount,
+		lastSyncAt, createdAt, updatedAt, groups, projects,
+	), nil
+}
+
+func buildConnectorFilterConditions(filters outbound.ConnectorFilters) ([]string, []interface{}) {
+	var conditions []string
+	var args []interface{}
+	argIdx := 1
+
+	if filters.ConnectorType != nil {
+		conditions = append(conditions, fmt.Sprintf("connector_type = $%d", argIdx))
+		args = append(args, filters.ConnectorType.String())
+		argIdx++
+	}
+
+	if filters.Status != nil {
+		conditions = append(conditions, fmt.Sprintf("status = $%d", argIdx))
+		args = append(args, filters.Status.String())
+	}
+
+	return conditions, args
+}
+
+func buildConnectorOrderBy(sort string) string {
+	switch sort {
+	case "name:asc":
+		return " ORDER BY name ASC"
+	case "name:desc":
+		return " ORDER BY name DESC"
+	case "created_at:asc":
+		return " ORDER BY created_at ASC"
+	case "created_at:desc":
+		return " ORDER BY created_at DESC"
+	default:
+		return " ORDER BY created_at DESC"
+	}
+}

--- a/internal/application/common/converter.go
+++ b/internal/application/common/converter.go
@@ -8,6 +8,21 @@ import (
 	"strings"
 )
 
+// EntityToConnectorResponse converts a Connector entity to a ConnectorResponse DTO.
+func EntityToConnectorResponse(c *entity.Connector) *dto.ConnectorResponse {
+	return &dto.ConnectorResponse{
+		ID:              c.ID(),
+		Name:            c.Name(),
+		ConnectorType:   c.ConnectorType().String(),
+		BaseURL:         c.BaseURL(),
+		Status:          c.Status().String(),
+		RepositoryCount: c.RepositoryCount(),
+		LastSyncAt:      c.LastSyncAt(),
+		CreatedAt:       c.CreatedAt(),
+		UpdatedAt:       c.UpdatedAt(),
+	}
+}
+
 const (
 	// MinURLPartsForOwnerRepo is the minimum number of URL parts needed to extract owner/repo format.
 	MinURLPartsForOwnerRepo = 2

--- a/internal/application/dto/connector.go
+++ b/internal/application/dto/connector.go
@@ -1,0 +1,111 @@
+package dto
+
+import (
+	"codechunking/internal/domain/valueobject"
+	"errors"
+	"net/url"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	// DefaultConnectorLimit is the default page size for connector list queries.
+	DefaultConnectorLimit = 20
+)
+
+// CreateConnectorRequest is the payload for creating a new connector.
+type CreateConnectorRequest struct {
+	Name          string  `json:"name"`
+	ConnectorType string  `json:"connector_type"`
+	BaseURL       string  `json:"base_url"`
+	AuthToken     *string `json:"auth_token,omitempty"`
+}
+
+// Validate checks that the request contains all required, well-formed fields.
+func (r CreateConnectorRequest) Validate() error {
+	if r.Name == "" {
+		return errors.New("name is required")
+	}
+	if len(r.Name) > 255 {
+		return errors.New("name must not exceed 255 characters")
+	}
+	if r.ConnectorType == "" {
+		return errors.New("connector_type is required")
+	}
+	if _, err := valueobject.NewConnectorType(r.ConnectorType); err != nil {
+		return err
+	}
+	if r.BaseURL == "" {
+		return errors.New("base_url is required")
+	}
+	u, err := url.ParseRequestURI(r.BaseURL)
+	if err != nil || (u.Scheme != "https" && u.Scheme != "http") {
+		return errors.New("base_url must be a valid http or https URL")
+	}
+	return nil
+}
+
+// ConnectorResponse is the representation of a connector returned by the API.
+// The auth token is intentionally excluded for security.
+type ConnectorResponse struct {
+	ID              uuid.UUID  `json:"id"`
+	Name            string     `json:"name"`
+	ConnectorType   string     `json:"connector_type"`
+	BaseURL         string     `json:"base_url"`
+	Status          string     `json:"status"`
+	RepositoryCount int        `json:"repository_count"`
+	LastSyncAt      *time.Time `json:"last_sync_at,omitempty"`
+	CreatedAt       time.Time  `json:"created_at"`
+	UpdatedAt       time.Time  `json:"updated_at"`
+}
+
+// ConnectorListResponse wraps a page of connectors with pagination metadata.
+type ConnectorListResponse struct {
+	Connectors []ConnectorResponse `json:"connectors"`
+	Pagination PaginationResponse  `json:"pagination"`
+}
+
+// ConnectorListQuery holds the parameters used to filter and page connector lists.
+type ConnectorListQuery struct {
+	ConnectorType string `form:"connector_type"`
+	Status        string `form:"status"`
+	Limit         int    `form:"limit"`
+	Offset        int    `form:"offset"`
+}
+
+// DefaultConnectorListQuery returns the default query parameters.
+func DefaultConnectorListQuery() ConnectorListQuery {
+	return ConnectorListQuery{
+		Limit:  DefaultConnectorLimit,
+		Offset: 0,
+	}
+}
+
+// Validate checks that the query parameters are within acceptable ranges.
+func (q ConnectorListQuery) Validate() error {
+	if q.ConnectorType != "" {
+		if _, err := valueobject.NewConnectorType(q.ConnectorType); err != nil {
+			return err
+		}
+	}
+	if q.Status != "" {
+		if _, err := valueobject.NewConnectorStatus(q.Status); err != nil {
+			return err
+		}
+	}
+	if q.Limit > MaxLimitValue {
+		return errors.New("limit exceeds maximum allowed value")
+	}
+	if q.Offset < 0 {
+		return errors.New("offset must not be negative")
+	}
+	return nil
+}
+
+// SyncConnectorResponse is returned when a sync is triggered.
+type SyncConnectorResponse struct {
+	ConnectorID       uuid.UUID `json:"connector_id"`
+	RepositoriesFound int       `json:"repositories_found"`
+	Message           string    `json:"message"`
+}

--- a/internal/application/dto/connector_test.go
+++ b/internal/application/dto/connector_test.go
@@ -1,0 +1,200 @@
+package dto
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateConnectorRequest_RequiredFields(t *testing.T) {
+	t.Run("valid_request_with_all_fields", func(t *testing.T) {
+		authToken := "ghp_test"
+		req := CreateConnectorRequest{
+			Name:          "my-org-connector",
+			ConnectorType: "gitlab",
+			BaseURL:       "https://gitlab.com",
+			AuthToken:     &authToken,
+		}
+
+		assert.Equal(t, "my-org-connector", req.Name)
+		assert.Equal(t, "gitlab", req.ConnectorType)
+		assert.Equal(t, "https://gitlab.com", req.BaseURL)
+		require.NotNil(t, req.AuthToken)
+		assert.Equal(t, authToken, *req.AuthToken)
+	})
+
+	t.Run("valid_request_without_auth_token", func(t *testing.T) {
+		req := CreateConnectorRequest{
+			Name:          "my-gitlab-connector",
+			ConnectorType: "gitlab",
+			BaseURL:       "https://gitlab.com",
+		}
+
+		assert.Equal(t, "my-gitlab-connector", req.Name)
+		assert.Nil(t, req.AuthToken)
+	})
+}
+
+func TestCreateConnectorRequest_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		req     CreateConnectorRequest
+		wantErr bool
+	}{
+		{
+			name: "valid_request",
+			req: CreateConnectorRequest{
+				Name:          "test-connector",
+				ConnectorType: "gitlab",
+				BaseURL:       "https://gitlab.com",
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty_name_returns_error",
+			req: CreateConnectorRequest{
+				Name:          "",
+				ConnectorType: "gitlab",
+				BaseURL:       "https://gitlab.com",
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty_connector_type_returns_error",
+			req: CreateConnectorRequest{
+				Name:          "test-connector",
+				ConnectorType: "",
+				BaseURL:       "https://gitlab.com",
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty_base_url_returns_error",
+			req: CreateConnectorRequest{
+				Name:          "test-connector",
+				ConnectorType: "gitlab",
+				BaseURL:       "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid_connector_type_returns_error",
+			req: CreateConnectorRequest{
+				Name:          "test-connector",
+				ConnectorType: "not_a_valid_type",
+				BaseURL:       "https://gitlab.com",
+			},
+			wantErr: true,
+		},
+		{
+			name: "name_exceeding_max_length_returns_error",
+			req: CreateConnectorRequest{
+				Name:          string(make([]byte, 256)),
+				ConnectorType: "gitlab",
+				BaseURL:       "https://gitlab.com",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.req.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestDefaultConnectorListQuery(t *testing.T) {
+	q := DefaultConnectorListQuery()
+
+	assert.Equal(t, DefaultConnectorLimit, q.Limit)
+	assert.Equal(t, 0, q.Offset)
+	assert.Empty(t, q.ConnectorType)
+	assert.Empty(t, q.Status)
+}
+
+func TestConnectorListQuery_DefaultLimit(t *testing.T) {
+	q := DefaultConnectorListQuery()
+	assert.Positive(t, q.Limit, "default limit should be positive")
+	assert.LessOrEqual(t, q.Limit, MaxLimitValue, "default limit should not exceed max limit")
+}
+
+func TestConnectorListQuery_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		query   ConnectorListQuery
+		wantErr bool
+	}{
+		{
+			name:    "default_query_is_valid",
+			query:   DefaultConnectorListQuery(),
+			wantErr: false,
+		},
+		{
+			name: "valid_connector_type_filter",
+			query: ConnectorListQuery{
+				ConnectorType: "gitlab",
+				Limit:         10,
+				Offset:        0,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid_status_filter",
+			query: ConnectorListQuery{
+				Status: "active",
+				Limit:  10,
+				Offset: 0,
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid_connector_type_filter_returns_error",
+			query: ConnectorListQuery{
+				ConnectorType: "not_valid",
+				Limit:         10,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid_status_filter_returns_error",
+			query: ConnectorListQuery{
+				Status: "not_valid",
+				Limit:  10,
+			},
+			wantErr: true,
+		},
+		{
+			name: "limit_over_max_returns_error",
+			query: ConnectorListQuery{
+				Limit: MaxLimitValue + 1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative_offset_returns_error",
+			query: ConnectorListQuery{
+				Limit:  10,
+				Offset: -1,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.query.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/application/service/connector_reconciler.go
+++ b/internal/application/service/connector_reconciler.go
@@ -1,0 +1,215 @@
+package service
+
+import (
+	"codechunking/internal/application/common/slogger"
+	"codechunking/internal/config"
+	"codechunking/internal/domain/entity"
+	"codechunking/internal/domain/valueobject"
+	"codechunking/internal/port/outbound"
+	"context"
+	"fmt"
+	"os"
+)
+
+// reconcilerFetchLimit is a high limit used to load all connectors from the DB in a single pass.
+const reconcilerFetchLimit = 1_000_000
+
+// ConnectorReconciler reconciles connector configuration with the database state.
+// Config is the single source of truth: connectors in config are created/updated,
+// and connectors removed from config are marked inactive.
+type ConnectorReconciler struct {
+	connectorRepo outbound.ConnectorRepository
+}
+
+// NewConnectorReconciler creates a new ConnectorReconciler.
+func NewConnectorReconciler(repo outbound.ConnectorRepository) *ConnectorReconciler {
+	return &ConnectorReconciler{connectorRepo: repo}
+}
+
+// Reconcile syncs the database connector state with cfgConnectors.
+// It is non-fatal: errors for individual connectors are logged and skipped.
+func (r *ConnectorReconciler) Reconcile(ctx context.Context, cfgConnectors []config.ConnectorConfig) error {
+	dbConnectors, _, err := r.connectorRepo.FindAll(ctx, outbound.ConnectorFilters{Limit: reconcilerFetchLimit})
+	if err != nil {
+		return fmt.Errorf("loading connectors from db: %w", err)
+	}
+
+	// Build name → entity map from DB.
+	dbByName := make(map[string]*entity.Connector, len(dbConnectors))
+	for _, c := range dbConnectors {
+		dbByName[c.Name()] = c
+	}
+
+	// Build config name set for removal detection.
+	configNames := make(map[string]bool, len(cfgConnectors))
+	for _, cfg := range cfgConnectors {
+		configNames[cfg.Name] = true
+	}
+
+	// Upsert pass: create or update each config connector.
+	for _, cfg := range cfgConnectors {
+		r.upsertConnector(ctx, cfg, dbByName)
+	}
+
+	// Deactivation pass: mark DB connectors absent from config as inactive.
+	for name, connector := range dbByName {
+		if configNames[name] {
+			continue
+		}
+		if connector.Status() == valueobject.ConnectorStatusInactive {
+			continue
+		}
+		connector.MarkInactive()
+		if err := r.connectorRepo.Update(ctx, connector); err != nil {
+			slogger.Error(ctx, "connector reconciler: failed to mark connector inactive", slogger.Fields{
+				"name":  name,
+				"error": err.Error(),
+			})
+			continue
+		}
+		slogger.Info(ctx, "connector removed from config, marking inactive", slogger.Fields{"name": name})
+	}
+
+	return nil
+}
+
+// upsertConnector creates or updates a single connector based on config.
+func (r *ConnectorReconciler) upsertConnector(
+	ctx context.Context,
+	cfg config.ConnectorConfig,
+	dbByName map[string]*entity.Connector,
+) {
+	ct, err := valueobject.NewConnectorType(cfg.Type)
+	if err != nil {
+		slogger.Error(ctx, "connector reconciler: invalid connector type in config, skipping", slogger.Fields{
+			"name":  cfg.Name,
+			"type":  cfg.Type,
+			"error": err.Error(),
+		})
+		return
+	}
+
+	authToken := os.ExpandEnv(cfg.AuthToken)
+	var authTokenPtr *string
+	if authToken != "" {
+		authTokenPtr = &authToken
+	}
+
+	groups := cfg.Groups
+	if groups == nil {
+		groups = []string{}
+	}
+	projects := cfg.Projects
+	if projects == nil {
+		projects = []string{}
+	}
+
+	existing, inDB := dbByName[cfg.Name]
+	if !inDB {
+		r.createConnector(ctx, cfg.Name, ct, cfg.BaseURL, authTokenPtr, groups, projects)
+		return
+	}
+
+	r.updateConnectorIfChanged(ctx, existing, cfg.BaseURL, authTokenPtr, authToken, groups, projects)
+}
+
+// createConnector creates and persists a new connector entity.
+func (r *ConnectorReconciler) createConnector(
+	ctx context.Context,
+	name string,
+	ct valueobject.ConnectorType,
+	baseURL string,
+	authToken *string,
+	groups, projects []string,
+) {
+	connector, err := entity.NewConnector(name, ct, baseURL, authToken, groups, projects)
+	if err != nil {
+		slogger.Error(ctx, "connector reconciler: failed to build connector entity", slogger.Fields{
+			"name":  name,
+			"error": err.Error(),
+		})
+		return
+	}
+	if err := r.connectorRepo.Save(ctx, connector); err != nil {
+		slogger.Error(ctx, "connector reconciler: failed to save new connector", slogger.Fields{
+			"name":  name,
+			"error": err.Error(),
+		})
+		return
+	}
+	slogger.Info(ctx, "connector reconciler: connector created from config", slogger.Fields{"name": name})
+}
+
+// updateConnectorIfChanged applies config changes to an existing DB connector and persists if needed.
+func (r *ConnectorReconciler) updateConnectorIfChanged(
+	ctx context.Context,
+	existing *entity.Connector,
+	baseURL string,
+	authTokenPtr *string,
+	authTokenPlain string,
+	groups, projects []string,
+) {
+	changed := false
+
+	if existing.Status() == valueobject.ConnectorStatusInactive {
+		if err := existing.Activate(); err != nil {
+			slogger.Error(ctx, "connector reconciler: failed to reactivate connector", slogger.Fields{
+				"name":  existing.Name(),
+				"error": err.Error(),
+			})
+		} else {
+			changed = true
+			slogger.Info(ctx, "connector reconciler: reactivating connector", slogger.Fields{"name": existing.Name()})
+		}
+	}
+
+	if existing.BaseURL() != baseURL {
+		existing.SetBaseURL(baseURL)
+		changed = true
+	}
+
+	existingToken := ""
+	if existing.AuthToken() != nil {
+		existingToken = *existing.AuthToken()
+	}
+	if existingToken != authTokenPlain {
+		existing.SetAuthToken(authTokenPtr)
+		changed = true
+	}
+
+	if !stringSlicesEqual(existing.Groups(), groups) {
+		existing.SetGroups(groups)
+		changed = true
+	}
+
+	if !stringSlicesEqual(existing.Projects(), projects) {
+		existing.SetProjects(projects)
+		changed = true
+	}
+
+	if !changed {
+		return
+	}
+
+	if err := r.connectorRepo.Update(ctx, existing); err != nil {
+		slogger.Error(ctx, "connector reconciler: failed to update connector", slogger.Fields{
+			"name":  existing.Name(),
+			"error": err.Error(),
+		})
+		return
+	}
+	slogger.Info(ctx, "connector reconciler: connector updated from config", slogger.Fields{"name": existing.Name()})
+}
+
+// stringSlicesEqual reports whether two string slices are equal element-by-element.
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/application/service/connector_reconciler_test.go
+++ b/internal/application/service/connector_reconciler_test.go
@@ -1,0 +1,314 @@
+package service_test
+
+import (
+	"codechunking/internal/application/common/logging"
+	"codechunking/internal/application/common/slogger"
+	appservice "codechunking/internal/application/service"
+	"codechunking/internal/config"
+	"codechunking/internal/domain/entity"
+	domainerrors "codechunking/internal/domain/errors/domain"
+	"codechunking/internal/domain/valueobject"
+	"codechunking/internal/port/outbound"
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// In-memory repository for reconciler tests
+// ---------------------------------------------------------------------------
+
+type memConnectorRepo struct {
+	connectors   []*entity.Connector
+	saveCalled   int
+	updateCalled int
+}
+
+func (m *memConnectorRepo) Save(_ context.Context, connector *entity.Connector) error {
+	m.connectors = append(m.connectors, connector)
+	m.saveCalled++
+	return nil
+}
+
+func (m *memConnectorRepo) FindByID(_ context.Context, id uuid.UUID) (*entity.Connector, error) {
+	for _, c := range m.connectors {
+		if c.ID() == id {
+			return c, nil
+		}
+	}
+	return nil, domainerrors.ErrConnectorNotFound
+}
+
+func (m *memConnectorRepo) FindByName(_ context.Context, name string) (*entity.Connector, error) {
+	for _, c := range m.connectors {
+		if c.Name() == name {
+			return c, nil
+		}
+	}
+	return nil, domainerrors.ErrConnectorNotFound
+}
+
+func (m *memConnectorRepo) FindAll(_ context.Context, _ outbound.ConnectorFilters) ([]*entity.Connector, int, error) {
+	return m.connectors, len(m.connectors), nil
+}
+
+func (m *memConnectorRepo) Update(_ context.Context, connector *entity.Connector) error {
+	m.updateCalled++
+	for i, c := range m.connectors {
+		if c.ID() == connector.ID() {
+			m.connectors[i] = connector
+			return nil
+		}
+	}
+	return errors.New("connector not found for update")
+}
+
+func (m *memConnectorRepo) Delete(_ context.Context, id uuid.UUID) error {
+	for i, c := range m.connectors {
+		if c.ID() == id {
+			m.connectors = append(m.connectors[:i], m.connectors[i+1:]...)
+			return nil
+		}
+	}
+	return domainerrors.ErrConnectorNotFound
+}
+
+func (m *memConnectorRepo) Exists(_ context.Context, name string) (bool, error) {
+	for _, c := range m.connectors {
+		if c.Name() == name {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (m *memConnectorRepo) connectorByName(name string) *entity.Connector {
+	for _, c := range m.connectors {
+		if c.Name() == name {
+			return c
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+func initReconcilerLogger(t *testing.T) {
+	t.Helper()
+	silentLogger, err := logging.NewApplicationLogger(logging.Config{
+		Level:  "ERROR",
+		Format: "json",
+		Output: "buffer",
+	})
+	require.NoError(t, err)
+	slogger.SetGlobalLogger(silentLogger)
+}
+
+func restoreConnectorActive(name string) *entity.Connector {
+	now := time.Now()
+	c := entity.RestoreConnector(
+		uuid.New(), name, valueobject.ConnectorTypeGitLab,
+		"https://gitlab.com", nil,
+		valueobject.ConnectorStatusActive, 0, nil,
+		now, now,
+		[]string{"old-group"}, []string{},
+	)
+	return c
+}
+
+func restoreConnectorInactive(name string) *entity.Connector {
+	now := time.Now()
+	c := entity.RestoreConnector(
+		uuid.New(), name, valueobject.ConnectorTypeGitLab,
+		"https://gitlab.com", nil,
+		valueobject.ConnectorStatusInactive, 0, nil,
+		now, now,
+		[]string{}, []string{},
+	)
+	return c
+}
+
+func gitlabCfg(name string) config.ConnectorConfig {
+	return config.ConnectorConfig{
+		Name:     name,
+		Type:     "gitlab",
+		BaseURL:  "https://gitlab.com",
+		Groups:   []string{"my-group"},
+		Projects: []string{},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// Case 1: empty config + empty DB → no-op.
+func TestConnectorReconciler_EmptyConfigAndDB_NoOp(t *testing.T) {
+	initReconcilerLogger(t)
+	repo := &memConnectorRepo{}
+	r := appservice.NewConnectorReconciler(repo)
+
+	err := r.Reconcile(context.Background(), nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, repo.saveCalled)
+	assert.Equal(t, 0, repo.updateCalled)
+}
+
+// Case 2: config connector not in DB → created.
+func TestConnectorReconciler_NewConfigConnector_IsCreated(t *testing.T) {
+	initReconcilerLogger(t)
+	repo := &memConnectorRepo{}
+	r := appservice.NewConnectorReconciler(repo)
+
+	err := r.Reconcile(context.Background(), []config.ConnectorConfig{gitlabCfg("my-gitlab")})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, repo.saveCalled, "expected one connector to be saved")
+	assert.Equal(t, 0, repo.updateCalled)
+
+	c := repo.connectorByName("my-gitlab")
+	require.NotNil(t, c)
+	assert.Equal(t, valueobject.ConnectorTypeGitLab, c.ConnectorType())
+	assert.Equal(t, []string{"my-group"}, c.Groups())
+}
+
+// Case 3: config connector in DB, unchanged → no update called.
+func TestConnectorReconciler_UnchangedConnector_NoUpdate(t *testing.T) {
+	initReconcilerLogger(t)
+	repo := &memConnectorRepo{}
+	existing := entity.RestoreConnector(
+		uuid.New(), "my-gitlab", valueobject.ConnectorTypeGitLab,
+		"https://gitlab.com", nil,
+		valueobject.ConnectorStatusActive, 0, nil,
+		time.Now(), time.Now(),
+		[]string{"my-group"}, []string{},
+	)
+	repo.connectors = []*entity.Connector{existing}
+
+	r := appservice.NewConnectorReconciler(repo)
+	err := r.Reconcile(context.Background(), []config.ConnectorConfig{gitlabCfg("my-gitlab")})
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, repo.saveCalled)
+	assert.Equal(t, 0, repo.updateCalled, "unchanged connector should not trigger an update")
+}
+
+// Case 4: config connector in DB, baseURL changed → updated.
+func TestConnectorReconciler_BaseURLChanged_Updated(t *testing.T) {
+	initReconcilerLogger(t)
+	repo := &memConnectorRepo{}
+	existing := restoreConnectorActive("my-gitlab")
+	repo.connectors = []*entity.Connector{existing}
+
+	cfg := gitlabCfg("my-gitlab")
+	cfg.BaseURL = "https://new-gitlab.example.com"
+
+	r := appservice.NewConnectorReconciler(repo)
+	err := r.Reconcile(context.Background(), []config.ConnectorConfig{cfg})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, repo.updateCalled)
+
+	c := repo.connectorByName("my-gitlab")
+	require.NotNil(t, c)
+	assert.Equal(t, "https://new-gitlab.example.com", c.BaseURL())
+}
+
+// Case 5: config connector in DB, groups list changed → updated.
+func TestConnectorReconciler_GroupsChanged_Updated(t *testing.T) {
+	initReconcilerLogger(t)
+	repo := &memConnectorRepo{}
+	existing := restoreConnectorActive("my-gitlab")
+	repo.connectors = []*entity.Connector{existing}
+
+	cfg := gitlabCfg("my-gitlab")
+	cfg.Groups = []string{"group-a", "group-b"}
+
+	r := appservice.NewConnectorReconciler(repo)
+	err := r.Reconcile(context.Background(), []config.ConnectorConfig{cfg})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, repo.updateCalled)
+
+	c := repo.connectorByName("my-gitlab")
+	require.NotNil(t, c)
+	assert.Equal(t, []string{"group-a", "group-b"}, c.Groups())
+}
+
+// Case 6: config connector was inactive → reactivated on reconcile.
+func TestConnectorReconciler_InactiveConnector_Reactivated(t *testing.T) {
+	initReconcilerLogger(t)
+	repo := &memConnectorRepo{}
+	inactive := restoreConnectorInactive("my-gitlab")
+	repo.connectors = []*entity.Connector{inactive}
+
+	r := appservice.NewConnectorReconciler(repo)
+	err := r.Reconcile(context.Background(), []config.ConnectorConfig{gitlabCfg("my-gitlab")})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, repo.updateCalled, "reactivation should trigger an update")
+
+	c := repo.connectorByName("my-gitlab")
+	require.NotNil(t, c)
+	assert.Equal(t, valueobject.ConnectorStatusActive, c.Status())
+}
+
+// Case 7: DB connector not in config → marked inactive.
+func TestConnectorReconciler_RemovedFromConfig_MarkedInactive(t *testing.T) {
+	initReconcilerLogger(t)
+	repo := &memConnectorRepo{}
+	active := restoreConnectorActive("stale-connector")
+	repo.connectors = []*entity.Connector{active}
+
+	r := appservice.NewConnectorReconciler(repo)
+	// Reconcile with empty config → stale-connector should be deactivated.
+	err := r.Reconcile(context.Background(), nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, repo.updateCalled)
+
+	c := repo.connectorByName("stale-connector")
+	require.NotNil(t, c)
+	assert.Equal(t, valueobject.ConnectorStatusInactive, c.Status())
+}
+
+// Case 8: DB connector already inactive, not in config → no update called (idempotent).
+func TestConnectorReconciler_AlreadyInactive_NotInConfig_NoUpdate(t *testing.T) {
+	initReconcilerLogger(t)
+	repo := &memConnectorRepo{}
+	inactive := restoreConnectorInactive("old-connector")
+	repo.connectors = []*entity.Connector{inactive}
+
+	r := appservice.NewConnectorReconciler(repo)
+	err := r.Reconcile(context.Background(), nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, repo.updateCalled, "already-inactive connector should not be updated")
+}
+
+// Case 9: invalid type in config → logged and skipped, rest still reconciles.
+func TestConnectorReconciler_InvalidTypeInConfig_SkipsAndContinues(t *testing.T) {
+	initReconcilerLogger(t)
+	repo := &memConnectorRepo{}
+
+	cfgs := []config.ConnectorConfig{
+		{Name: "bad-connector", Type: "invalid_type", BaseURL: "https://gitlab.com"},
+		gitlabCfg("good-connector"),
+	}
+
+	r := appservice.NewConnectorReconciler(repo)
+	err := r.Reconcile(context.Background(), cfgs)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, repo.saveCalled, "only the valid connector should be saved")
+	assert.Nil(t, repo.connectorByName("bad-connector"), "invalid connector should not be persisted")
+	assert.NotNil(t, repo.connectorByName("good-connector"), "valid connector should be persisted")
+}

--- a/internal/application/service/connector_service.go
+++ b/internal/application/service/connector_service.go
@@ -1,0 +1,156 @@
+package service
+
+import (
+	"codechunking/internal/application/common"
+	"codechunking/internal/application/common/slogger"
+	"codechunking/internal/application/dto"
+	domainerrors "codechunking/internal/domain/errors/domain"
+	"codechunking/internal/domain/valueobject"
+	"codechunking/internal/port/outbound"
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// =============================================================================
+// GetConnectorService
+// =============================================================================
+
+// GetConnectorService handles fetching a single connector.
+type GetConnectorService struct {
+	connectorRepo outbound.ConnectorRepository
+}
+
+// NewGetConnectorService constructs a GetConnectorService.
+func NewGetConnectorService(connectorRepo outbound.ConnectorRepository) *GetConnectorService {
+	return &GetConnectorService{connectorRepo: connectorRepo}
+}
+
+// GetConnector returns a connector by ID.
+func (s *GetConnectorService) GetConnector(ctx context.Context, id uuid.UUID) (*dto.ConnectorResponse, error) {
+	slogger.Info(ctx, "Getting connector", slogger.Fields{"id": id})
+
+	connector, err := s.connectorRepo.FindByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	return common.EntityToConnectorResponse(connector), nil
+}
+
+// =============================================================================
+// ListConnectorsService
+// =============================================================================
+
+// ListConnectorsService handles listing connectors with filters.
+type ListConnectorsService struct {
+	connectorRepo outbound.ConnectorRepository
+}
+
+// NewListConnectorsService constructs a ListConnectorsService.
+func NewListConnectorsService(connectorRepo outbound.ConnectorRepository) *ListConnectorsService {
+	return &ListConnectorsService{connectorRepo: connectorRepo}
+}
+
+// ListConnectors returns a paginated list of connectors.
+func (s *ListConnectorsService) ListConnectors(
+	ctx context.Context,
+	query dto.ConnectorListQuery,
+) (*dto.ConnectorListResponse, error) {
+	slogger.Info(ctx, "Listing connectors", slogger.Fields{"limit": query.Limit, "offset": query.Offset})
+
+	filters := outbound.ConnectorFilters{
+		Limit:  query.Limit,
+		Offset: query.Offset,
+	}
+
+	if query.ConnectorType != "" {
+		ct, err := valueobject.NewConnectorType(query.ConnectorType)
+		if err != nil {
+			return nil, err
+		}
+		filters.ConnectorType = &ct
+	}
+
+	if query.Status != "" {
+		cs, err := valueobject.NewConnectorStatus(query.Status)
+		if err != nil {
+			return nil, err
+		}
+		filters.Status = &cs
+	}
+
+	connectors, total, err := s.connectorRepo.FindAll(ctx, filters)
+	if err != nil {
+		return nil, fmt.Errorf("listing connectors: %w", err)
+	}
+
+	responses := make([]dto.ConnectorResponse, 0, len(connectors))
+	for _, c := range connectors {
+		r := common.EntityToConnectorResponse(c)
+		responses = append(responses, *r)
+	}
+
+	return &dto.ConnectorListResponse{
+		Connectors: responses,
+		Pagination: dto.PaginationResponse{
+			Limit:   query.Limit,
+			Offset:  query.Offset,
+			Total:   total,
+			HasMore: query.Offset+len(responses) < total,
+		},
+	}, nil
+}
+
+// =============================================================================
+// SyncConnectorService
+// =============================================================================
+
+// SyncConnectorService triggers a sync for a connector.
+type SyncConnectorService struct {
+	connectorRepo outbound.ConnectorRepository
+}
+
+// NewSyncConnectorService constructs a SyncConnectorService.
+func NewSyncConnectorService(connectorRepo outbound.ConnectorRepository) *SyncConnectorService {
+	return &SyncConnectorService{connectorRepo: connectorRepo}
+}
+
+// SyncConnector marks the connector as syncing and returns a response.
+func (s *SyncConnectorService) SyncConnector(
+	ctx context.Context,
+	id uuid.UUID,
+) (*dto.SyncConnectorResponse, error) {
+	slogger.Info(ctx, "Triggering connector sync", slogger.Fields{"id": id})
+
+	connector, err := s.connectorRepo.FindByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	if connector.Status() == valueobject.ConnectorStatusSyncing {
+		return nil, domainerrors.ErrConnectorSyncing
+	}
+
+	// A freshly reconciled connector starts in pending state.
+	// Promote it to active before transitioning to syncing.
+	if connector.Status() == valueobject.ConnectorStatusPending {
+		if err := connector.UpdateStatus(valueobject.ConnectorStatusActive); err != nil {
+			return nil, fmt.Errorf("activating pending connector: %w", err)
+		}
+	}
+
+	if err := connector.MarkSyncStarted(); err != nil {
+		return nil, fmt.Errorf("marking sync started: %w", err)
+	}
+
+	if err := s.connectorRepo.Update(ctx, connector); err != nil {
+		return nil, fmt.Errorf("updating connector: %w", err)
+	}
+
+	return &dto.SyncConnectorResponse{
+		ConnectorID: id,
+		Message:     "sync triggered successfully",
+	}, nil
+}

--- a/internal/application/service/connector_service_test.go
+++ b/internal/application/service/connector_service_test.go
@@ -1,0 +1,283 @@
+package service
+
+import (
+	"codechunking/internal/application/common/logging"
+	"codechunking/internal/application/common/slogger"
+	"codechunking/internal/application/dto"
+	"codechunking/internal/domain/entity"
+	domainerrors "codechunking/internal/domain/errors/domain"
+	"codechunking/internal/domain/valueobject"
+	"codechunking/internal/port/outbound"
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+var errInternalTest = errors.New("internal test error")
+
+// MockConnectorRepository is a testify mock for outbound.ConnectorRepository.
+type MockConnectorRepository struct {
+	mock.Mock
+}
+
+func (m *MockConnectorRepository) Save(ctx context.Context, connector *entity.Connector) error {
+	args := m.Called(ctx, connector)
+	return args.Error(0)
+}
+
+func (m *MockConnectorRepository) FindByID(ctx context.Context, id uuid.UUID) (*entity.Connector, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*entity.Connector), args.Error(1)
+}
+
+func (m *MockConnectorRepository) FindByName(ctx context.Context, name string) (*entity.Connector, error) {
+	args := m.Called(ctx, name)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*entity.Connector), args.Error(1)
+}
+
+func (m *MockConnectorRepository) FindAll(
+	ctx context.Context,
+	filters outbound.ConnectorFilters,
+) ([]*entity.Connector, int, error) {
+	args := m.Called(ctx, filters)
+	if args.Get(0) == nil {
+		return nil, args.Int(1), args.Error(2)
+	}
+	return args.Get(0).([]*entity.Connector), args.Int(1), args.Error(2)
+}
+
+func (m *MockConnectorRepository) Update(ctx context.Context, connector *entity.Connector) error {
+	args := m.Called(ctx, connector)
+	return args.Error(0)
+}
+
+func (m *MockConnectorRepository) Delete(ctx context.Context, id uuid.UUID) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
+func (m *MockConnectorRepository) Exists(ctx context.Context, name string) (bool, error) {
+	args := m.Called(ctx, name)
+	return args.Bool(0), args.Error(1)
+}
+
+// silentConnectorLogger sets up a silent logger for tests.
+func silentConnectorLogger(t *testing.T) {
+	t.Helper()
+	silentLogger, err := logging.NewApplicationLogger(logging.Config{
+		Level:  "ERROR",
+		Format: "json",
+		Output: "buffer",
+	})
+	require.NoError(t, err)
+	slogger.SetGlobalLogger(silentLogger)
+}
+
+// buildTestConnector creates a test connector entity in active status.
+func buildTestConnector(t *testing.T, id uuid.UUID, name string) *entity.Connector {
+	t.Helper()
+	now := time.Now()
+	return entity.RestoreConnector(
+		id,
+		name,
+		valueobject.ConnectorTypeGitLab,
+		"https://gitlab.com",
+		nil,
+		valueobject.ConnectorStatusActive,
+		5,
+		nil,
+		now,
+		now,
+		[]string{},
+		[]string{},
+	)
+}
+
+// =============================================================================
+// GetConnector tests
+// =============================================================================
+
+func TestGetConnectorService_GetConnector_Success(t *testing.T) {
+	silentConnectorLogger(t)
+
+	mockRepo := new(MockConnectorRepository)
+	service := NewGetConnectorService(mockRepo)
+
+	connectorID := uuid.New()
+	connector := buildTestConnector(t, connectorID, "my-connector")
+
+	mockRepo.On("FindByID", mock.Anything, connectorID).Return(connector, nil)
+
+	ctx := context.Background()
+	response, err := service.GetConnector(ctx, connectorID)
+
+	require.NoError(t, err)
+	require.NotNil(t, response)
+	assert.Equal(t, connectorID, response.ID)
+	assert.Equal(t, "my-connector", response.Name)
+
+	mockRepo.AssertExpectations(t)
+}
+
+func TestGetConnectorService_GetConnector_NotFound(t *testing.T) {
+	silentConnectorLogger(t)
+
+	mockRepo := new(MockConnectorRepository)
+	service := NewGetConnectorService(mockRepo)
+
+	connectorID := uuid.New()
+	mockRepo.On("FindByID", mock.Anything, connectorID).Return(nil, domainerrors.ErrConnectorNotFound)
+
+	ctx := context.Background()
+	response, err := service.GetConnector(ctx, connectorID)
+
+	require.Error(t, err)
+	assert.Nil(t, response)
+	assert.ErrorIs(t, err, domainerrors.ErrConnectorNotFound)
+
+	mockRepo.AssertExpectations(t)
+}
+
+// =============================================================================
+// ListConnectors tests
+// =============================================================================
+
+func TestListConnectorsService_ListConnectors_Success(t *testing.T) {
+	silentConnectorLogger(t)
+
+	mockRepo := new(MockConnectorRepository)
+	service := NewListConnectorsService(mockRepo)
+
+	connectors := []*entity.Connector{
+		buildTestConnector(t, uuid.New(), "connector-1"),
+		buildTestConnector(t, uuid.New(), "connector-2"),
+	}
+
+	query := dto.DefaultConnectorListQuery()
+	mockRepo.On("FindAll", mock.Anything, mock.AnythingOfType("outbound.ConnectorFilters")).
+		Return(connectors, 2, nil)
+
+	ctx := context.Background()
+	response, err := service.ListConnectors(ctx, query)
+
+	require.NoError(t, err)
+	require.NotNil(t, response)
+	assert.Len(t, response.Connectors, 2)
+	assert.Equal(t, 2, response.Pagination.Total)
+
+	mockRepo.AssertExpectations(t)
+}
+
+func TestListConnectorsService_ListConnectors_Empty(t *testing.T) {
+	silentConnectorLogger(t)
+
+	mockRepo := new(MockConnectorRepository)
+	service := NewListConnectorsService(mockRepo)
+
+	query := dto.DefaultConnectorListQuery()
+	mockRepo.On("FindAll", mock.Anything, mock.AnythingOfType("outbound.ConnectorFilters")).
+		Return([]*entity.Connector{}, 0, nil)
+
+	ctx := context.Background()
+	response, err := service.ListConnectors(ctx, query)
+
+	require.NoError(t, err)
+	require.NotNil(t, response)
+	assert.Empty(t, response.Connectors)
+	assert.Equal(t, 0, response.Pagination.Total)
+
+	mockRepo.AssertExpectations(t)
+}
+
+// =============================================================================
+// SyncConnector tests
+// =============================================================================
+
+func TestSyncConnectorService_SyncConnector_Success(t *testing.T) {
+	silentConnectorLogger(t)
+
+	mockRepo := new(MockConnectorRepository)
+	service := NewSyncConnectorService(mockRepo)
+
+	connectorID := uuid.New()
+	connector := buildTestConnector(t, connectorID, "my-connector")
+
+	mockRepo.On("FindByID", mock.Anything, connectorID).Return(connector, nil)
+	mockRepo.On("Update", mock.Anything, mock.AnythingOfType("*entity.Connector")).Return(nil)
+
+	ctx := context.Background()
+	response, err := service.SyncConnector(ctx, connectorID)
+
+	require.NoError(t, err)
+	require.NotNil(t, response)
+	assert.Equal(t, connectorID, response.ConnectorID)
+	assert.NotEmpty(t, response.Message)
+
+	mockRepo.AssertExpectations(t)
+}
+
+func TestSyncConnectorService_SyncConnector_NotFound(t *testing.T) {
+	silentConnectorLogger(t)
+
+	mockRepo := new(MockConnectorRepository)
+	service := NewSyncConnectorService(mockRepo)
+
+	connectorID := uuid.New()
+	mockRepo.On("FindByID", mock.Anything, connectorID).Return(nil, domainerrors.ErrConnectorNotFound)
+
+	ctx := context.Background()
+	response, err := service.SyncConnector(ctx, connectorID)
+
+	require.Error(t, err)
+	assert.Nil(t, response)
+	assert.ErrorIs(t, err, domainerrors.ErrConnectorNotFound)
+
+	mockRepo.AssertExpectations(t)
+}
+
+func TestSyncConnectorService_SyncConnector_AlreadySyncing(t *testing.T) {
+	silentConnectorLogger(t)
+
+	mockRepo := new(MockConnectorRepository)
+	service := NewSyncConnectorService(mockRepo)
+
+	connectorID := uuid.New()
+	now := time.Now()
+	syncingConnector := entity.RestoreConnector(
+		connectorID,
+		"syncing-connector",
+		valueobject.ConnectorTypeGitLab,
+		"https://gitlab.com",
+		nil,
+		valueobject.ConnectorStatusSyncing,
+		0,
+		nil,
+		now,
+		now,
+		[]string{},
+		[]string{},
+	)
+
+	mockRepo.On("FindByID", mock.Anything, connectorID).Return(syncingConnector, nil)
+
+	ctx := context.Background()
+	response, err := service.SyncConnector(ctx, connectorID)
+
+	require.Error(t, err)
+	assert.Nil(t, response)
+	assert.ErrorIs(t, err, domainerrors.ErrConnectorSyncing)
+
+	mockRepo.AssertExpectations(t)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,17 @@ import (
 	"github.com/spf13/viper"
 )
 
+// ConnectorConfig holds configuration for a single git connector.
+// Auth tokens may reference environment variables using ${VAR_NAME} syntax.
+type ConnectorConfig struct {
+	Name      string   `mapstructure:"name"`
+	Type      string   `mapstructure:"type"`
+	BaseURL   string   `mapstructure:"base_url"`
+	AuthToken string   `mapstructure:"auth_token"`
+	Groups    []string `mapstructure:"groups"`
+	Projects  []string `mapstructure:"projects"`
+}
+
 // Config holds the complete application configuration.
 type Config struct {
 	API             APIConfig             `mapstructure:"api"`
@@ -18,6 +29,7 @@ type Config struct {
 	Gemini          GeminiConfig          `mapstructure:"gemini"`
 	BatchProcessing BatchProcessingConfig `mapstructure:"batch_processing"`
 	Log             LogConfig             `mapstructure:"log"`
+	Connectors      []ConnectorConfig     `mapstructure:"connectors"`
 }
 
 // APIConfig holds API server configuration.

--- a/internal/domain/entity/connector.go
+++ b/internal/domain/entity/connector.go
@@ -1,0 +1,228 @@
+package entity
+
+import (
+	"codechunking/internal/domain/valueobject"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Connector represents a git provider integration (e.g. a GitHub org or GitLab group).
+type Connector struct {
+	id              uuid.UUID
+	name            string
+	connectorType   valueobject.ConnectorType
+	baseURL         string
+	authToken       *string
+	status          valueobject.ConnectorStatus
+	repositoryCount int
+	lastSyncAt      *time.Time
+	createdAt       time.Time
+	updatedAt       time.Time
+	groups          []string
+	projects        []string
+}
+
+// NewConnector creates a new Connector with the given parameters.
+func NewConnector(
+	name string,
+	connectorType valueobject.ConnectorType,
+	baseURL string,
+	authToken *string,
+	groups []string,
+	projects []string,
+) (*Connector, error) {
+	if name == "" {
+		return nil, errors.New("connector name cannot be empty")
+	}
+	if baseURL == "" {
+		return nil, errors.New("connector base URL cannot be empty")
+	}
+
+	if groups == nil {
+		groups = []string{}
+	}
+	if projects == nil {
+		projects = []string{}
+	}
+
+	now := time.Now()
+	return &Connector{
+		id:            uuid.New(),
+		name:          name,
+		connectorType: connectorType,
+		baseURL:       baseURL,
+		authToken:     authToken,
+		status:        valueobject.ConnectorStatusPending,
+		groups:        groups,
+		projects:      projects,
+		createdAt:     now,
+		updatedAt:     now,
+	}, nil
+}
+
+// RestoreConnector recreates a Connector from persisted data (bypasses validation).
+func RestoreConnector(
+	id uuid.UUID,
+	name string,
+	connectorType valueobject.ConnectorType,
+	baseURL string,
+	authToken *string,
+	status valueobject.ConnectorStatus,
+	repositoryCount int,
+	lastSyncAt *time.Time,
+	createdAt time.Time,
+	updatedAt time.Time,
+	groups []string,
+	projects []string,
+) *Connector {
+	if groups == nil {
+		groups = []string{}
+	}
+	if projects == nil {
+		projects = []string{}
+	}
+	return &Connector{
+		id:              id,
+		name:            name,
+		connectorType:   connectorType,
+		baseURL:         baseURL,
+		authToken:       authToken,
+		status:          status,
+		repositoryCount: repositoryCount,
+		lastSyncAt:      lastSyncAt,
+		createdAt:       createdAt,
+		updatedAt:       updatedAt,
+		groups:          groups,
+		projects:        projects,
+	}
+}
+
+// Accessors.
+
+// ID returns the connector's unique identifier.
+func (c *Connector) ID() uuid.UUID { return c.id }
+
+// Name returns the connector's name.
+func (c *Connector) Name() string { return c.name }
+
+// ConnectorType returns the connector type.
+func (c *Connector) ConnectorType() valueobject.ConnectorType { return c.connectorType }
+
+// BaseURL returns the provider base URL.
+func (c *Connector) BaseURL() string { return c.baseURL }
+
+// AuthToken returns the optional auth token.
+func (c *Connector) AuthToken() *string { return c.authToken }
+
+// Status returns the current status.
+func (c *Connector) Status() valueobject.ConnectorStatus { return c.status }
+
+// RepositoryCount returns the number of repositories discovered by the last sync.
+func (c *Connector) RepositoryCount() int { return c.repositoryCount }
+
+// LastSyncAt returns the time of the last successful sync, or nil.
+func (c *Connector) LastSyncAt() *time.Time { return c.lastSyncAt }
+
+// CreatedAt returns the creation timestamp.
+func (c *Connector) CreatedAt() time.Time { return c.createdAt }
+
+// UpdatedAt returns the last-update timestamp.
+func (c *Connector) UpdatedAt() time.Time { return c.updatedAt }
+
+// Groups returns the list of GitLab group paths to sync.
+func (c *Connector) Groups() []string { return c.groups }
+
+// Projects returns the list of individual GitLab project paths to sync.
+func (c *Connector) Projects() []string { return c.projects }
+
+// Mutators.
+
+// SetBaseURL updates the base URL and bumps updatedAt.
+func (c *Connector) SetBaseURL(url string) {
+	c.baseURL = url
+	c.updatedAt = time.Now()
+}
+
+// SetAuthToken updates the auth token and bumps updatedAt.
+func (c *Connector) SetAuthToken(token *string) {
+	c.authToken = token
+	c.updatedAt = time.Now()
+}
+
+// SetGroups updates the groups list and bumps updatedAt.
+func (c *Connector) SetGroups(groups []string) {
+	if groups == nil {
+		groups = []string{}
+	}
+	c.groups = groups
+	c.updatedAt = time.Now()
+}
+
+// SetProjects updates the projects list and bumps updatedAt.
+func (c *Connector) SetProjects(projects []string) {
+	if projects == nil {
+		projects = []string{}
+	}
+	c.projects = projects
+	c.updatedAt = time.Now()
+}
+
+// UpdateStatus transitions the connector to the given status.
+// Returns an error if the transition is not allowed.
+func (c *Connector) UpdateStatus(target valueobject.ConnectorStatus) error {
+	if !c.status.CanTransitionTo(target) {
+		return errors.New("invalid status transition from " + c.status.String() + " to " + target.String())
+	}
+	c.status = target
+	c.updatedAt = time.Now()
+	return nil
+}
+
+// MarkSyncStarted transitions the connector into the syncing state.
+func (c *Connector) MarkSyncStarted() error {
+	return c.UpdateStatus(valueobject.ConnectorStatusSyncing)
+}
+
+// MarkSyncCompleted transitions back to active and records the repository count.
+func (c *Connector) MarkSyncCompleted(repositoryCount int) error {
+	if err := c.UpdateStatus(valueobject.ConnectorStatusActive); err != nil {
+		return err
+	}
+	c.repositoryCount = repositoryCount
+	now := time.Now()
+	c.lastSyncAt = &now
+	c.updatedAt = now
+	return nil
+}
+
+// MarkSyncFailed transitions the connector to the error state.
+func (c *Connector) MarkSyncFailed() error {
+	return c.UpdateStatus(valueobject.ConnectorStatusError)
+}
+
+// Deactivate transitions the connector to inactive via the normal state machine.
+func (c *Connector) Deactivate() error {
+	return c.UpdateStatus(valueobject.ConnectorStatusInactive)
+}
+
+// Activate transitions the connector to active.
+func (c *Connector) Activate() error {
+	return c.UpdateStatus(valueobject.ConnectorStatusActive)
+}
+
+// MarkInactive forcefully sets the connector status to inactive regardless of current state.
+// Used by the reconciler to deactivate connectors removed from config.
+func (c *Connector) MarkInactive() {
+	c.status = valueobject.ConnectorStatusInactive
+	c.updatedAt = time.Now()
+}
+
+// Equal reports whether two connectors share the same identity.
+func (c *Connector) Equal(other *Connector) bool {
+	if other == nil {
+		return false
+	}
+	return c.id == other.id
+}

--- a/internal/domain/entity/connector_test.go
+++ b/internal/domain/entity/connector_test.go
@@ -1,0 +1,322 @@
+package entity
+
+import (
+	"codechunking/internal/domain/valueobject"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewConnector_ValidData(t *testing.T) {
+	authToken := "glpat-testtoken123"
+
+	connector, err := NewConnector(
+		"my-gitlab-group",
+		valueobject.ConnectorTypeGitLab,
+		"https://gitlab.com",
+		&authToken,
+		[]string{"my-group"},
+		[]string{"my-group/my-project"},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, connector)
+
+	assert.NotEqual(t, uuid.Nil, connector.ID())
+	assert.Equal(t, "my-gitlab-group", connector.Name())
+	assert.Equal(t, valueobject.ConnectorTypeGitLab, connector.ConnectorType())
+	assert.Equal(t, "https://gitlab.com", connector.BaseURL())
+	require.NotNil(t, connector.AuthToken())
+	assert.Equal(t, authToken, *connector.AuthToken())
+	assert.Equal(t, valueobject.ConnectorStatusPending, connector.Status())
+	assert.Equal(t, 0, connector.RepositoryCount())
+	assert.Nil(t, connector.LastSyncAt())
+	assert.Equal(t, []string{"my-group"}, connector.Groups())
+	assert.Equal(t, []string{"my-group/my-project"}, connector.Projects())
+
+	now := time.Now()
+	assert.WithinDuration(t, now, connector.CreatedAt(), 5*time.Second)
+	assert.WithinDuration(t, now, connector.UpdatedAt(), 5*time.Second)
+}
+
+func TestNewConnector_WithoutAuthToken(t *testing.T) {
+	connector, err := NewConnector(
+		"my-gitlab-connector",
+		valueobject.ConnectorTypeGitLab,
+		"https://gitlab.example.com",
+		nil,
+		nil,
+		nil,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, connector)
+	assert.Nil(t, connector.AuthToken())
+	assert.Equal(t, []string{}, connector.Groups())
+	assert.Equal(t, []string{}, connector.Projects())
+}
+
+func TestNewConnector_EmptyNameReturnsError(t *testing.T) {
+	_, err := NewConnector(
+		"",
+		valueobject.ConnectorTypeGitLab,
+		"https://gitlab.com",
+		nil,
+		nil,
+		nil,
+	)
+
+	require.Error(t, err)
+}
+
+func TestNewConnector_EmptyBaseURLReturnsError(t *testing.T) {
+	_, err := NewConnector(
+		"my-connector",
+		valueobject.ConnectorTypeGitLab,
+		"",
+		nil,
+		nil,
+		nil,
+	)
+
+	require.Error(t, err)
+}
+
+func TestNewConnector_UniqueIDsPerInstance(t *testing.T) {
+	c1, err := NewConnector("connector-1", valueobject.ConnectorTypeGitLab, "https://gitlab.com", nil, nil, nil)
+	require.NoError(t, err)
+
+	c2, err := NewConnector("connector-2", valueobject.ConnectorTypeGitLab, "https://gitlab.example.com", nil, nil, nil)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, c1.ID(), c2.ID())
+}
+
+func TestConnector_AllConnectorTypesSupported(t *testing.T) {
+	types := []valueobject.ConnectorType{
+		valueobject.ConnectorTypeGitLab,
+	}
+
+	for _, ct := range types {
+		t.Run(ct.String(), func(t *testing.T) {
+			connector, err := NewConnector("test-connector", ct, "https://example.com", nil, nil, nil)
+			require.NoError(t, err)
+			assert.Equal(t, ct, connector.ConnectorType())
+		})
+	}
+}
+
+func TestConnector_UpdateStatus_ValidTransition(t *testing.T) {
+	connector, err := NewConnector(
+		"my-connector",
+		valueobject.ConnectorTypeGitLab,
+		"https://gitlab.com",
+		nil,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+
+	// pending → active
+	err = connector.UpdateStatus(valueobject.ConnectorStatusActive)
+	require.NoError(t, err)
+	assert.Equal(t, valueobject.ConnectorStatusActive, connector.Status())
+}
+
+func TestConnector_UpdateStatus_InvalidTransition(t *testing.T) {
+	connector, err := NewConnector(
+		"my-connector",
+		valueobject.ConnectorTypeGitLab,
+		"https://gitlab.com",
+		nil,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+
+	// pending → inactive is invalid via UpdateStatus
+	err = connector.UpdateStatus(valueobject.ConnectorStatusInactive)
+	require.Error(t, err)
+	// Status should remain unchanged
+	assert.Equal(t, valueobject.ConnectorStatusPending, connector.Status())
+}
+
+func TestConnector_MarkInactive_ForceFromAnyState(t *testing.T) {
+	connector, err := NewConnector(
+		"my-connector",
+		valueobject.ConnectorTypeGitLab,
+		"https://gitlab.com",
+		nil,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+
+	// pending → inactive via MarkInactive (force bypass)
+	connector.MarkInactive()
+	assert.Equal(t, valueobject.ConnectorStatusInactive, connector.Status())
+}
+
+func TestConnector_MarkSyncStarted(t *testing.T) {
+	connector, err := NewConnector(
+		"my-connector",
+		valueobject.ConnectorTypeGitLab,
+		"https://gitlab.com",
+		nil,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+
+	// Activate first
+	require.NoError(t, connector.UpdateStatus(valueobject.ConnectorStatusActive))
+
+	// Start sync
+	err = connector.MarkSyncStarted()
+	require.NoError(t, err)
+	assert.Equal(t, valueobject.ConnectorStatusSyncing, connector.Status())
+}
+
+func TestConnector_MarkSyncCompleted(t *testing.T) {
+	connector, err := NewConnector(
+		"my-connector",
+		valueobject.ConnectorTypeGitLab,
+		"https://gitlab.com",
+		nil,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, connector.UpdateStatus(valueobject.ConnectorStatusActive))
+	require.NoError(t, connector.MarkSyncStarted())
+
+	err = connector.MarkSyncCompleted(42)
+	require.NoError(t, err)
+	assert.Equal(t, valueobject.ConnectorStatusActive, connector.Status())
+	assert.Equal(t, 42, connector.RepositoryCount())
+	require.NotNil(t, connector.LastSyncAt())
+	assert.WithinDuration(t, time.Now(), *connector.LastSyncAt(), 5*time.Second)
+}
+
+func TestConnector_MarkSyncFailed(t *testing.T) {
+	connector, err := NewConnector(
+		"my-connector",
+		valueobject.ConnectorTypeGitLab,
+		"https://gitlab.com",
+		nil,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, connector.UpdateStatus(valueobject.ConnectorStatusActive))
+	require.NoError(t, connector.MarkSyncStarted())
+
+	err = connector.MarkSyncFailed()
+	require.NoError(t, err)
+	assert.Equal(t, valueobject.ConnectorStatusError, connector.Status())
+}
+
+func TestConnector_Deactivate(t *testing.T) {
+	connector, err := NewConnector(
+		"my-connector",
+		valueobject.ConnectorTypeGitLab,
+		"https://gitlab.com",
+		nil,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, connector.UpdateStatus(valueobject.ConnectorStatusActive))
+
+	err = connector.Deactivate()
+	require.NoError(t, err)
+	assert.Equal(t, valueobject.ConnectorStatusInactive, connector.Status())
+}
+
+func TestConnector_Equal(t *testing.T) {
+	connector, err := NewConnector("c1", valueobject.ConnectorTypeGitLab, "https://gitlab.com", nil, nil, nil)
+	require.NoError(t, err)
+
+	t.Run("same_id_is_equal", func(t *testing.T) {
+		assert.True(t, connector.Equal(connector))
+	})
+
+	t.Run("different_id_is_not_equal", func(t *testing.T) {
+		other, err := NewConnector("c2", valueobject.ConnectorTypeGitLab, "https://gitlab.com", nil, nil, nil)
+		require.NoError(t, err)
+		assert.False(t, connector.Equal(other))
+	})
+
+	t.Run("nil_is_not_equal", func(t *testing.T) {
+		assert.False(t, connector.Equal(nil))
+	})
+}
+
+func TestConnector_Setters(t *testing.T) {
+	connector, err := NewConnector(
+		"my-connector",
+		valueobject.ConnectorTypeGitLab,
+		"https://gitlab.com",
+		nil,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+
+	connector.SetBaseURL("https://new-gitlab.com")
+	assert.Equal(t, "https://new-gitlab.com", connector.BaseURL())
+
+	token := "newtoken"
+	connector.SetAuthToken(&token)
+	require.NotNil(t, connector.AuthToken())
+	assert.Equal(t, token, *connector.AuthToken())
+
+	connector.SetGroups([]string{"group1", "group2"})
+	assert.Equal(t, []string{"group1", "group2"}, connector.Groups())
+
+	connector.SetProjects([]string{"group1/proj1"})
+	assert.Equal(t, []string{"group1/proj1"}, connector.Projects())
+}
+
+func TestRestoreConnector(t *testing.T) {
+	id := uuid.New()
+	authToken := "token123"
+	repoCount := 10
+	lastSync := time.Now().Add(-1 * time.Hour)
+	now := time.Now()
+
+	connector := RestoreConnector(
+		id,
+		"restored-connector",
+		valueobject.ConnectorTypeGitLab,
+		"https://gitlab.com",
+		&authToken,
+		valueobject.ConnectorStatusActive,
+		repoCount,
+		&lastSync,
+		now,
+		now,
+		[]string{"my-group"},
+		[]string{"my-group/my-project"},
+	)
+
+	require.NotNil(t, connector)
+	assert.Equal(t, id, connector.ID())
+	assert.Equal(t, "restored-connector", connector.Name())
+	assert.Equal(t, valueobject.ConnectorTypeGitLab, connector.ConnectorType())
+	assert.Equal(t, "https://gitlab.com", connector.BaseURL())
+	require.NotNil(t, connector.AuthToken())
+	assert.Equal(t, authToken, *connector.AuthToken())
+	assert.Equal(t, valueobject.ConnectorStatusActive, connector.Status())
+	assert.Equal(t, repoCount, connector.RepositoryCount())
+	require.NotNil(t, connector.LastSyncAt())
+	assert.WithinDuration(t, lastSync, *connector.LastSyncAt(), time.Second)
+	assert.Equal(t, []string{"my-group"}, connector.Groups())
+	assert.Equal(t, []string{"my-group/my-project"}, connector.Projects())
+}

--- a/internal/domain/errors/domain/errors.go
+++ b/internal/domain/errors/domain/errors.go
@@ -18,6 +18,13 @@ var (
 	ErrJobFailed   = errors.New("indexing job failed")
 )
 
+// Connector-related errors.
+var (
+	ErrConnectorNotFound      = errors.New("connector not found")
+	ErrConnectorAlreadyExists = errors.New("connector already exists")
+	ErrConnectorSyncing       = errors.New("connector is currently syncing")
+)
+
 // General domain errors.
 var (
 	ErrInvalidInput = errors.New("invalid input")

--- a/internal/domain/valueobject/connector_status.go
+++ b/internal/domain/valueobject/connector_status.go
@@ -1,0 +1,64 @@
+package valueobject
+
+import "fmt"
+
+// ConnectorStatus represents the operational status of a connector.
+type ConnectorStatus string
+
+// Connector status constants.
+const (
+	ConnectorStatusPending  ConnectorStatus = "pending"
+	ConnectorStatusActive   ConnectorStatus = "active"
+	ConnectorStatusInactive ConnectorStatus = "inactive"
+	ConnectorStatusSyncing  ConnectorStatus = "syncing"
+	ConnectorStatusError    ConnectorStatus = "error"
+)
+
+// NewConnectorStatus creates a validated ConnectorStatus from a string.
+func NewConnectorStatus(s string) (ConnectorStatus, error) {
+	cs := ConnectorStatus(s)
+	switch cs {
+	case ConnectorStatusPending, ConnectorStatusActive, ConnectorStatusInactive,
+		ConnectorStatusSyncing, ConnectorStatusError:
+		return cs, nil
+	}
+	return "", fmt.Errorf("invalid connector status: %s", s)
+}
+
+// String returns the string representation of the connector status.
+func (cs ConnectorStatus) String() string {
+	return string(cs)
+}
+
+// IsTerminal reports whether this status is a final, non-recoverable state.
+func (cs ConnectorStatus) IsTerminal() bool {
+	return cs == ConnectorStatusInactive
+}
+
+// CanTransitionTo reports whether the connector can move from this status to target.
+func (cs ConnectorStatus) CanTransitionTo(target ConnectorStatus) bool {
+	switch cs {
+	case ConnectorStatusPending:
+		return target == ConnectorStatusActive || target == ConnectorStatusError
+	case ConnectorStatusActive:
+		return target == ConnectorStatusSyncing || target == ConnectorStatusInactive || target == ConnectorStatusError
+	case ConnectorStatusSyncing:
+		return target == ConnectorStatusActive || target == ConnectorStatusError
+	case ConnectorStatusInactive:
+		return target == ConnectorStatusActive
+	case ConnectorStatusError:
+		return target == ConnectorStatusPending || target == ConnectorStatusInactive
+	}
+	return false
+}
+
+// AllConnectorStatuses returns all valid connector statuses in a stable order.
+func AllConnectorStatuses() []ConnectorStatus {
+	return []ConnectorStatus{
+		ConnectorStatusPending,
+		ConnectorStatusActive,
+		ConnectorStatusInactive,
+		ConnectorStatusSyncing,
+		ConnectorStatusError,
+	}
+}

--- a/internal/domain/valueobject/connector_status_test.go
+++ b/internal/domain/valueobject/connector_status_test.go
@@ -1,0 +1,148 @@
+package valueobject
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewConnectorStatus_ValidStatuses(t *testing.T) {
+	validStatuses := []struct {
+		input    string
+		expected ConnectorStatus
+	}{
+		{"pending", ConnectorStatusPending},
+		{"active", ConnectorStatusActive},
+		{"inactive", ConnectorStatusInactive},
+		{"syncing", ConnectorStatusSyncing},
+		{"error", ConnectorStatusError},
+	}
+
+	for _, tc := range validStatuses {
+		t.Run(tc.input, func(t *testing.T) {
+			cs, err := NewConnectorStatus(tc.input)
+			require.NoError(t, err, "expected no error for valid connector status %s", tc.input)
+			assert.Equal(t, tc.expected, cs)
+		})
+	}
+}
+
+func TestNewConnectorStatus_InvalidStatuses(t *testing.T) {
+	invalidStatuses := []string{
+		"invalid",
+		"ACTIVE",
+		"Active",
+		"",
+		" pending",
+		"pending ",
+		"running",
+		"completed",
+		"unknown",
+	}
+
+	for _, input := range invalidStatuses {
+		t.Run(input, func(t *testing.T) {
+			_, err := NewConnectorStatus(input)
+			require.Error(t, err, "expected error for invalid connector status %q", input)
+		})
+	}
+}
+
+func TestConnectorStatus_String(t *testing.T) {
+	tests := []struct {
+		cs       ConnectorStatus
+		expected string
+	}{
+		{ConnectorStatusPending, "pending"},
+		{ConnectorStatusActive, "active"},
+		{ConnectorStatusInactive, "inactive"},
+		{ConnectorStatusSyncing, "syncing"},
+		{ConnectorStatusError, "error"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.cs.String())
+		})
+	}
+}
+
+func TestConnectorStatus_CanTransitionTo(t *testing.T) {
+	tests := []struct {
+		name   string
+		from   ConnectorStatus
+		to     ConnectorStatus
+		expect bool
+	}{
+		// pending can go to active or error
+		{"pending_to_active", ConnectorStatusPending, ConnectorStatusActive, true},
+		{"pending_to_error", ConnectorStatusPending, ConnectorStatusError, true},
+		{"pending_to_inactive", ConnectorStatusPending, ConnectorStatusInactive, false},
+		{"pending_to_syncing", ConnectorStatusPending, ConnectorStatusSyncing, false},
+
+		// active can sync, go inactive, or error
+		{"active_to_syncing", ConnectorStatusActive, ConnectorStatusSyncing, true},
+		{"active_to_inactive", ConnectorStatusActive, ConnectorStatusInactive, true},
+		{"active_to_error", ConnectorStatusActive, ConnectorStatusError, true},
+		{"active_to_pending", ConnectorStatusActive, ConnectorStatusPending, false},
+
+		// syncing can return to active or go to error
+		{"syncing_to_active", ConnectorStatusSyncing, ConnectorStatusActive, true},
+		{"syncing_to_error", ConnectorStatusSyncing, ConnectorStatusError, true},
+		{"syncing_to_inactive", ConnectorStatusSyncing, ConnectorStatusInactive, false},
+		{"syncing_to_pending", ConnectorStatusSyncing, ConnectorStatusPending, false},
+
+		// inactive can be reactivated or deleted (to pending)
+		{"inactive_to_active", ConnectorStatusInactive, ConnectorStatusActive, true},
+		{"inactive_to_pending", ConnectorStatusInactive, ConnectorStatusPending, false},
+
+		// error can be retried (back to pending) or deactivated
+		{"error_to_pending", ConnectorStatusError, ConnectorStatusPending, true},
+		{"error_to_inactive", ConnectorStatusError, ConnectorStatusInactive, true},
+		{"error_to_active", ConnectorStatusError, ConnectorStatusActive, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.from.CanTransitionTo(tt.to)
+			assert.Equal(t, tt.expect, result,
+				"transition from %s to %s: expected %v, got %v",
+				tt.from, tt.to, tt.expect, result)
+		})
+	}
+}
+
+func TestConnectorStatus_IsTerminal(t *testing.T) {
+	t.Run("inactive_is_terminal", func(t *testing.T) {
+		assert.True(t, ConnectorStatusInactive.IsTerminal())
+	})
+
+	t.Run("non_terminal_statuses", func(t *testing.T) {
+		nonTerminal := []ConnectorStatus{
+			ConnectorStatusPending,
+			ConnectorStatusActive,
+			ConnectorStatusSyncing,
+			ConnectorStatusError,
+		}
+		for _, cs := range nonTerminal {
+			assert.False(t, cs.IsTerminal(), "expected %s to not be terminal", cs)
+		}
+	})
+}
+
+func TestAllConnectorStatuses(t *testing.T) {
+	statuses := AllConnectorStatuses()
+	assert.Len(t, statuses, 5, "expected exactly 5 connector statuses")
+
+	statusSet := make(map[ConnectorStatus]bool)
+	for _, cs := range statuses {
+		statusSet[cs] = true
+	}
+
+	assert.True(t, statusSet[ConnectorStatusPending])
+	assert.True(t, statusSet[ConnectorStatusActive])
+	assert.True(t, statusSet[ConnectorStatusInactive])
+	assert.True(t, statusSet[ConnectorStatusSyncing])
+	assert.True(t, statusSet[ConnectorStatusError])
+}

--- a/internal/domain/valueobject/connector_type.go
+++ b/internal/domain/valueobject/connector_type.go
@@ -1,0 +1,37 @@
+package valueobject
+
+import "fmt"
+
+// ConnectorType represents the type of git connector.
+type ConnectorType string
+
+// Connector type constants.
+const (
+	ConnectorTypeGitLab ConnectorType = "gitlab"
+)
+
+// NewConnectorType creates a validated ConnectorType from a string.
+func NewConnectorType(s string) (ConnectorType, error) {
+	ct := ConnectorType(s)
+	if ct == ConnectorTypeGitLab {
+		return ct, nil
+	}
+	return "", fmt.Errorf("invalid connector type: %s", s)
+}
+
+// String returns the string representation of the connector type.
+func (ct ConnectorType) String() string {
+	return string(ct)
+}
+
+// IsValid reports whether the connector type is a recognized value.
+func (ct ConnectorType) IsValid() bool {
+	return ct == ConnectorTypeGitLab
+}
+
+// AllConnectorTypes returns all valid connector types in a stable order.
+func AllConnectorTypes() []ConnectorType {
+	return []ConnectorType{
+		ConnectorTypeGitLab,
+	}
+}

--- a/internal/domain/valueobject/connector_type_test.go
+++ b/internal/domain/valueobject/connector_type_test.go
@@ -1,0 +1,89 @@
+package valueobject
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewConnectorType_ValidTypes(t *testing.T) {
+	validTypes := []struct {
+		input    string
+		expected ConnectorType
+	}{
+		{"gitlab", ConnectorTypeGitLab},
+	}
+
+	for _, tc := range validTypes {
+		t.Run(tc.input, func(t *testing.T) {
+			ct, err := NewConnectorType(tc.input)
+			require.NoError(t, err, "expected no error for valid connector type %s", tc.input)
+			assert.Equal(t, tc.expected, ct)
+		})
+	}
+}
+
+func TestNewConnectorType_InvalidTypes(t *testing.T) {
+	invalidTypes := []string{
+		"invalid",
+		"GitHub_Org",
+		"GITHUB_ORG",
+		"",
+		" github_org",
+		"github_org ",
+		"github",
+		"gitlab_group",
+		"unknown",
+	}
+
+	for _, input := range invalidTypes {
+		t.Run(input, func(t *testing.T) {
+			_, err := NewConnectorType(input)
+			require.Error(t, err, "expected error for invalid connector type %q", input)
+		})
+	}
+}
+
+func TestConnectorType_String(t *testing.T) {
+	tests := []struct {
+		ct       ConnectorType
+		expected string
+	}{
+		{ConnectorTypeGitLab, "gitlab"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.ct.String())
+		})
+	}
+}
+
+func TestConnectorType_IsValid(t *testing.T) {
+	t.Run("valid_types_return_true", func(t *testing.T) {
+		validTypes := []ConnectorType{
+			ConnectorTypeGitLab,
+		}
+		for _, ct := range validTypes {
+			assert.True(t, ct.IsValid(), "expected %s to be valid", ct)
+		}
+	})
+
+	t.Run("invalid_type_returns_false", func(t *testing.T) {
+		ct := ConnectorType("not_a_real_type")
+		assert.False(t, ct.IsValid())
+	})
+}
+
+func TestAllConnectorTypes(t *testing.T) {
+	types := AllConnectorTypes()
+	assert.Len(t, types, 1, "expected exactly 1 connector type")
+
+	typeSet := make(map[ConnectorType]bool)
+	for _, ct := range types {
+		typeSet[ct] = true
+	}
+
+	assert.True(t, typeSet[ConnectorTypeGitLab])
+}

--- a/internal/port/inbound/connector_service.go
+++ b/internal/port/inbound/connector_service.go
@@ -1,0 +1,17 @@
+// Package inbound defines the inbound port for connector operations.
+package inbound
+
+import (
+	"codechunking/internal/application/dto"
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// ConnectorService defines the inbound port for managing git connectors.
+// The API is read-only; connectors are managed declaratively via config.
+type ConnectorService interface {
+	GetConnector(ctx context.Context, id uuid.UUID) (*dto.ConnectorResponse, error)
+	ListConnectors(ctx context.Context, query dto.ConnectorListQuery) (*dto.ConnectorListResponse, error)
+	SyncConnector(ctx context.Context, id uuid.UUID) (*dto.SyncConnectorResponse, error)
+}

--- a/internal/port/outbound/connector_repository.go
+++ b/internal/port/outbound/connector_repository.go
@@ -1,0 +1,30 @@
+// Package outbound defines the outbound ports for connector persistence.
+package outbound
+
+import (
+	"codechunking/internal/domain/entity"
+	"codechunking/internal/domain/valueobject"
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// ConnectorRepository defines the outbound port for connector persistence.
+type ConnectorRepository interface {
+	Save(ctx context.Context, connector *entity.Connector) error
+	FindByID(ctx context.Context, id uuid.UUID) (*entity.Connector, error)
+	FindByName(ctx context.Context, name string) (*entity.Connector, error)
+	FindAll(ctx context.Context, filters ConnectorFilters) ([]*entity.Connector, int, error)
+	Update(ctx context.Context, connector *entity.Connector) error
+	Delete(ctx context.Context, id uuid.UUID) error
+	Exists(ctx context.Context, name string) (bool, error)
+}
+
+// ConnectorFilters holds optional filters for querying connectors.
+type ConnectorFilters struct {
+	ConnectorType *valueobject.ConnectorType
+	Status        *valueobject.ConnectorStatus
+	Limit         int
+	Offset        int
+	Sort          string
+}

--- a/internal/port/outbound/git_provider.go
+++ b/internal/port/outbound/git_provider.go
@@ -1,0 +1,41 @@
+// Package outbound defines the outbound port for external git provider integrations.
+package outbound
+
+import (
+	"codechunking/internal/domain/entity"
+	"context"
+	"time"
+)
+
+// GitProvider defines the outbound port for communicating with external git hosting services.
+// Each supported platform (GitLab) provides a concrete implementation of this interface.
+type GitProvider interface {
+	// ListRepositories returns all repositories accessible via the given connector configuration.
+	// The connector supplies the base URL, credentials, and target org/group/project context.
+	ListRepositories(ctx context.Context, connector *entity.Connector) ([]GitProviderRepository, error)
+
+	// ValidateCredentials verifies that the credentials stored in the connector are valid and
+	// that the provider URL is reachable.  It returns nil when credentials are accepted.
+	ValidateCredentials(ctx context.Context, connector *entity.Connector) error
+}
+
+// GitProviderRepository describes a single repository returned by a GitProvider.
+type GitProviderRepository struct {
+	// Name is the short repository name (e.g. "my-service").
+	Name string
+
+	// URL is the clone URL for the repository.
+	URL string
+
+	// Description is an optional human-readable description.
+	Description string
+
+	// DefaultBranch is the primary branch (e.g. "main").
+	DefaultBranch string
+
+	// IsPrivate indicates whether the repository is private.
+	IsPrivate bool
+
+	// LastActivity is the timestamp of the most recent push/commit activity, when available.
+	LastActivity *time.Time
+}

--- a/migrations/000016_create_connectors.down.sql
+++ b/migrations/000016_create_connectors.down.sql
@@ -1,0 +1,5 @@
+-- Rollback: drop connectors table
+
+SET search_path TO codechunking, public;
+
+DROP TABLE IF EXISTS codechunking.connectors;

--- a/migrations/000016_create_connectors.up.sql
+++ b/migrations/000016_create_connectors.up.sql
@@ -1,0 +1,28 @@
+-- Migration: create connectors table
+-- This table stores git connector configurations used to automatically
+-- discover and index repositories from external git hosting services.
+
+SET search_path TO codechunking, public;
+
+CREATE TABLE IF NOT EXISTS codechunking.connectors (
+    id               UUID        PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name             VARCHAR(255) NOT NULL UNIQUE,
+    connector_type   VARCHAR(50)  NOT NULL,
+    base_url         VARCHAR(512) NOT NULL,
+    auth_token       TEXT,
+    status           VARCHAR(50)  NOT NULL DEFAULT 'pending',
+    repository_count INTEGER      NOT NULL DEFAULT 0,
+    last_sync_at     TIMESTAMP WITH TIME ZONE,
+    created_at       TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at       TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Indexes for common query patterns
+CREATE INDEX IF NOT EXISTS idx_connectors_connector_type ON codechunking.connectors (connector_type);
+CREATE INDEX IF NOT EXISTS idx_connectors_status         ON codechunking.connectors (status);
+CREATE INDEX IF NOT EXISTS idx_connectors_name           ON codechunking.connectors (name);
+
+-- Auto-update updated_at on row modification
+CREATE TRIGGER update_connectors_updated_at
+    BEFORE UPDATE ON codechunking.connectors
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/migrations/000017_update_connectors_gitlab_type.down.sql
+++ b/migrations/000017_update_connectors_gitlab_type.down.sql
@@ -1,0 +1,11 @@
+-- Reverse migration 000017: restore gitlab_group type and drop JSONB columns
+
+SET search_path TO codechunking, public;
+
+UPDATE codechunking.connectors
+    SET connector_type = 'gitlab_group'
+    WHERE connector_type = 'gitlab';
+
+ALTER TABLE codechunking.connectors
+    DROP COLUMN groups,
+    DROP COLUMN projects;

--- a/migrations/000017_update_connectors_gitlab_type.up.sql
+++ b/migrations/000017_update_connectors_gitlab_type.up.sql
@@ -1,0 +1,11 @@
+-- Migration 000017: add groups/projects JSONB columns and rename gitlab_group → gitlab
+
+SET search_path TO codechunking, public;
+
+ALTER TABLE codechunking.connectors
+    ADD COLUMN groups   JSONB NOT NULL DEFAULT '[]',
+    ADD COLUMN projects JSONB NOT NULL DEFAULT '[]';
+
+UPDATE codechunking.connectors
+    SET connector_type = 'gitlab'
+    WHERE connector_type = 'gitlab_group';


### PR DESCRIPTION
Implements the GitLab group connector — a single-provider distillation of the broader Git Connectors feature. Includes domain entity, value objects (ConnectorType/Status), ports, application service, DTO layer, REST API handler/routes, repository adapter, migrations, and the GitLabProvider HTTP client. All other provider implementations (GitHub, Bitbucket, Azure DevOps, Generic) are intentionally excluded.