### PR TITLE
perf: parallelize parsing, increase concurrency, async token counting…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,9 +99,9 @@ build-docker:
 	docker build -f docker/Dockerfile -t $(BINARY_NAME):latest .
 	@echo "Docker image built: $(BINARY_NAME):latest"
 
-## build-client: Build standalone client binary (no CGO, static binary)
+## build-client: Build standalone client binary
 build-client:
-	CGO_ENABLED=0 $(GO_CMD) build -o bin/codechunking-client ./cmd/client
+	CGO_ENABLED=1 $(GO_CMD) build -o bin/codechunking-client ./cmd/client
 	@echo "Client binary built: bin/codechunking-client"
 
 ## build-client-cross: Cross-compile client for Linux and macOS

--- a/configs/config.dev.yaml
+++ b/configs/config.dev.yaml
@@ -2,6 +2,7 @@
 zoekt:
   webserver:
     host: localhost
+    #grpc actually does run on 6070
     port: 6070
   indexing:
     git_index_path: zoekt-git-index
@@ -9,7 +10,7 @@ zoekt:
     timeout: 10m
   concurrent_indexing:
     enabled: true
-    max_concurrent_jobs: 2
+    max_concurrent_jobs: 12
     retry_attempts: 2
 
 database:
@@ -69,6 +70,6 @@ batch_processing:
   # Token counting configuration
   token_counting:
     enabled: true                    # Enable token counting
-    mode: "all"                      # Mode: "all", "sample", or "on_demand"
+    mode: "sample"                   # Mode: "all", "sample", or "on_demand"
     sample_percent: 10               # Percentage of chunks to sample (for "sample" mode)
     max_tokens_per_chunk: 8192       # Maximum tokens per chunk (Gemini embedding model limit)

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -6,7 +6,7 @@ api:
   write_timeout: 10s
 
 worker:
-  concurrency: 5
+  concurrency: 12
   queue_group: workers
   job_timeout: 30m  # Overall timeout for complete job processing
                     # Must be larger than (gemini.timeout × max_chunks_per_repo)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,7 @@ services:
   zoekt-webserver:
     image: ghcr.io/sourcegraph/zoekt:latest
     container_name: codechunking-zoekt-webserver
+    user: "1000:1000"
     command: ["zoekt-webserver", "-index", "/data/index", "-pprof", "-rpc" ]  # HTTP on 6070, gRPC on 6071
     ports:
       - name: zoekt-http
@@ -68,7 +69,7 @@ services:
         published: "6071"
         protocol: tcp
     volumes:
-      - zoekt_data:/data/index
+      - /tmp/zoekt-index:/data/index
     healthcheck:
       test: ["CMD-SHELL", "wget -q --spider http://localhost:6070/healthz || exit 1"]
       interval: 10s

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,6 @@
+# Zoekt stage - extract indexing binary
+FROM ghcr.io/sourcegraph/zoekt:latest AS zoekt
+
 # Build stage - use Debian-based image to avoid musl libc issues
 FROM golang:1.24-bookworm AS builder
 
@@ -48,6 +51,9 @@ WORKDIR /app
 
 # Copy binary from builder
 COPY --from=builder /app/codechunking /app/codechunking
+
+# Copy zoekt indexing binary
+COPY --from=zoekt /usr/local/bin/zoekt-git-index /usr/local/bin/zoekt-git-index
 
 # Copy configuration files
 COPY --from=builder /app/configs /app/configs

--- a/internal/adapter/outbound/treesitter/code_parser.go
+++ b/internal/adapter/outbound/treesitter/code_parser.go
@@ -12,17 +12,23 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
+	"golang.org/x/sync/errgroup"
 )
+
+// fileEntry holds an absolute and relative path pair collected during the walk phase.
+type fileEntry struct {
+	abs string
+	rel string
+}
 
 // TreeSitterCodeParser implements outbound.CodeParser using TreeSitter infrastructure.
 type TreeSitterCodeParser struct {
 	factory *ParserFactoryImpl
-	// Cache for cleaned base paths to avoid repeated operations
-	basePathCache map[string]string
 }
 
 // NewTreeSitterCodeParser creates a new TreeSitter-based code parser.
@@ -32,19 +38,17 @@ func NewTreeSitterCodeParser(ctx context.Context) (*TreeSitterCodeParser, error)
 		return nil, fmt.Errorf("failed to create parser factory: %w", err)
 	}
 
-	return &TreeSitterCodeParser{
-		factory:       factory,
-		basePathCache: make(map[string]string),
-	}, nil
+	return &TreeSitterCodeParser{factory: factory}, nil
 }
 
 // ParseDirectory implements outbound.CodeParser interface.
+// Phase A walks the directory collecting candidate file paths (single-threaded,
+// cache-friendly). Phase B dispatches parsing to a bounded errgroup worker pool.
 func (p *TreeSitterCodeParser) ParseDirectory(
 	ctx context.Context,
 	dirPath string,
 	config outbound.CodeParsingConfig,
 ) ([]outbound.CodeChunk, error) {
-	// Validate input parameters
 	if err := p.validateParseDirectoryInput(ctx, dirPath, config); err != nil {
 		return nil, fmt.Errorf("invalid input parameters: %w", err)
 	}
@@ -57,20 +61,20 @@ func (p *TreeSitterCodeParser) ParseDirectory(
 		"exclude_vendor":   config.ExcludeVendor,
 	})
 
-	var allChunks []outbound.CodeChunk
-	var processedFiles int
-	var skippedFiles int
+	// Phase A: collect candidate file paths.
+	cleanBase := filepath.Clean(dirPath)
+	var entries []fileEntry
+	var walkSkipped int
 
-	err := filepath.WalkDir(dirPath, func(path string, d fs.DirEntry, err error) error {
+	walkErr := filepath.WalkDir(dirPath, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			slogger.Warn(ctx, "Error walking directory", slogger.Fields{
 				"path":  path,
 				"error": err.Error(),
 			})
-			return err // Return the error to stop walking
+			return err
 		}
 
-		// Skip directories and files that are too large early to avoid unnecessary processing
 		if d.IsDir() {
 			if p.shouldSkipDirectory(path, config) {
 				slogger.Debug(ctx, "Skipping directory", slogger.Fields{"path": path})
@@ -79,61 +83,89 @@ func (p *TreeSitterCodeParser) ParseDirectory(
 			return nil
 		}
 
-		// Quick file size check before more expensive operations
-		if info, err := d.Info(); err == nil && config.MaxFileSizeBytes > 0 && info.Size() > config.MaxFileSizeBytes {
+		if info, infoErr := d.Info(); infoErr == nil && config.MaxFileSizeBytes > 0 && info.Size() > config.MaxFileSizeBytes {
 			slogger.Debug(ctx, "Skipping file due to size limit", slogger.Fields{
 				"path":      path,
 				"file_size": info.Size(),
 				"max_size":  config.MaxFileSizeBytes,
 			})
-			skippedFiles++
+			walkSkipped++
 			return nil
 		}
 
-		// Skip directories
-		if d.IsDir() {
-			if p.shouldSkipDirectory(path, config) {
-				slogger.Debug(ctx, "Skipping directory", slogger.Fields{"path": path})
-				return filepath.SkipDir
-			}
+		if !p.shouldProcessFile(path, d, config) {
+			walkSkipped++
 			return nil
 		}
 
-		// Process files
-		if p.shouldProcessFile(path, d, config) {
-			// Convert absolute path to repository-relative path with robust error handling
-			relativePath, err := p.calculateRelativePath(ctx, dirPath, path)
-			if err != nil {
-				slogger.Warn(ctx, "Failed to calculate relative path, skipping file", slogger.Fields{
-					"absolute_path": path,
-					"base_path":     dirPath,
-					"error":         err.Error(),
-				})
-				skippedFiles++
-				return nil // Continue walking other files
-			}
-
-			chunks, err := p.parseFile(ctx, path, relativePath, config)
-			if err != nil {
-				slogger.Warn(ctx, "Failed to parse file", slogger.Fields{
-					"file":          relativePath,
-					"absolute_path": path,
-					"error":         err.Error(),
-				})
-				skippedFiles++
-			} else {
-				allChunks = append(allChunks, chunks...)
-				processedFiles++
-			}
-		} else {
-			skippedFiles++
+		rel, relErr := filepath.Rel(cleanBase, filepath.Clean(path))
+		if relErr != nil {
+			slogger.Warn(ctx, "Failed to calculate relative path, skipping file", slogger.Fields{
+				"absolute_path": path,
+				"base_path":     dirPath,
+				"error":         relErr.Error(),
+			})
+			walkSkipped++
+			return nil //nolint:nilerr // intentionally skip unparseable paths to continue the walk
 		}
-
+		rel = filepath.ToSlash(rel)
+		entries = append(entries, fileEntry{abs: path, rel: rel})
 		return nil
 	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to walk directory %s: %w", dirPath, err)
+	if walkErr != nil {
+		return nil, fmt.Errorf("failed to walk directory %s: %w", dirPath, walkErr)
 	}
+
+	// Phase B: parse files in parallel with a bounded worker pool.
+	concurrency := config.ParseConcurrency
+	if concurrency <= 0 {
+		concurrency = runtime.GOMAXPROCS(0)
+	}
+
+	results := make(chan []outbound.CodeChunk, len(entries))
+	skippedCh := make(chan int, len(entries))
+
+	g, gCtx := errgroup.WithContext(ctx)
+	g.SetLimit(concurrency)
+
+	for _, e := range entries {
+		g.Go(func() error {
+			chunks, parseErr := p.parseFile(gCtx, e.abs, e.rel, config)
+			if parseErr != nil {
+				slogger.Warn(gCtx, "Failed to parse file", slogger.Fields{
+					"file":  e.rel,
+					"error": parseErr.Error(),
+				})
+				skippedCh <- 1
+				return nil //nolint:nilerr // file parse errors are skipped, not fatal
+			}
+			results <- chunks
+			return nil
+		})
+	}
+
+	// Close channels once all workers finish.
+	go func() {
+		_ = g.Wait()
+		close(results)
+		close(skippedCh)
+	}()
+
+	allChunks := make([]outbound.CodeChunk, 0, len(entries)*4)
+	for chunks := range results {
+		allChunks = append(allChunks, chunks...)
+	}
+
+	skippedFiles := walkSkipped
+	for range skippedCh {
+		skippedFiles++
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	processedFiles := len(entries) - (skippedFiles - walkSkipped)
 
 	slogger.Info(ctx, "Directory parsing completed", slogger.Fields{
 		"total_chunks":    len(allChunks),
@@ -142,7 +174,7 @@ func (p *TreeSitterCodeParser) ParseDirectory(
 		"directory":       dirPath,
 	})
 
-	// Filter out chunks with empty content to prevent validation errors later
+	// Filter out chunks with empty content to prevent validation errors later.
 	validChunks := make([]outbound.CodeChunk, 0, len(allChunks))
 	for _, chunk := range allChunks {
 		if strings.TrimSpace(chunk.Content) != "" {
@@ -167,116 +199,6 @@ func (p *TreeSitterCodeParser) ParseDirectory(
 	}
 
 	return validChunks, nil
-}
-
-// getCleanBasePath returns a cleaned base path, using cache for performance.
-func (p *TreeSitterCodeParser) getCleanBasePath(basePath string) string {
-	if cleaned, exists := p.basePathCache[basePath]; exists {
-		return cleaned
-	}
-
-	cleaned := filepath.Clean(basePath)
-	p.basePathCache[basePath] = cleaned
-	return cleaned
-}
-
-// calculateRelativePath converts an absolute file path to a repository-relative path
-// with robust error handling and validation.
-func (p *TreeSitterCodeParser) calculateRelativePath(
-	ctx context.Context,
-	basePath string,
-	absolutePath string,
-) (string, error) {
-	// Get cleaned base path from cache for performance
-	cleanBasePath := p.getCleanBasePath(basePath)
-	cleanAbsolutePath := filepath.Clean(absolutePath)
-
-	// Validate input parameters
-	if err := p.validatePathParameters(cleanBasePath, cleanAbsolutePath); err != nil {
-		return "", fmt.Errorf("invalid path parameters: %w", err)
-	}
-
-	// Calculate relative path using cleaned paths
-	relativePath, err := filepath.Rel(cleanBasePath, cleanAbsolutePath)
-	if err != nil {
-		return "", fmt.Errorf("failed to calculate relative path from %s to %s: %w",
-			cleanBasePath, cleanAbsolutePath, err)
-	}
-
-	// Validate the calculated relative path
-	if err := p.validateRelativePath(relativePath, cleanBasePath, cleanAbsolutePath); err != nil {
-		return "", fmt.Errorf("invalid relative path calculated: %w", err)
-	}
-
-	// Normalize path separators for consistency
-	relativePath = filepath.ToSlash(relativePath)
-
-	slogger.Debug(ctx, "Successfully calculated relative path", slogger.Fields{
-		"base_path":      basePath,
-		"absolute_path":  absolutePath,
-		"clean_base":     cleanBasePath,
-		"clean_absolute": cleanAbsolutePath,
-		"relative_path":  relativePath,
-	})
-
-	return relativePath, nil
-}
-
-// validatePathParameters validates the input parameters for path calculation.
-func (p *TreeSitterCodeParser) validatePathParameters(basePath, absolutePath string) error {
-	if basePath == "" {
-		return errors.New("base path cannot be empty")
-	}
-	if absolutePath == "" {
-		return errors.New("absolute path cannot be empty")
-	}
-
-	// Ensure paths are absolute
-	if !filepath.IsAbs(basePath) {
-		return fmt.Errorf("base path must be absolute: %s", basePath)
-	}
-	if !filepath.IsAbs(absolutePath) {
-		return fmt.Errorf("absolute path must be absolute: %s", absolutePath)
-	}
-
-	// Clean paths to remove any redundant elements
-	basePath = filepath.Clean(basePath)
-	absolutePath = filepath.Clean(absolutePath)
-
-	return nil
-}
-
-// validateRelativePath validates the calculated relative path for correctness.
-func (p *TreeSitterCodeParser) validateRelativePath(relativePath, basePath, absolutePath string) error {
-	if relativePath == "" {
-		return errors.New("calculated relative path is empty")
-	}
-
-	// Check if the relative path contains directory traversal attempts
-	if strings.Contains(relativePath, "..") {
-		// This might be legitimate in some cases, but log it for investigation
-		// We'll allow it but ensure it's safe by reconstructing and verifying
-		reconstructed := filepath.Join(basePath, relativePath)
-		reconstructed = filepath.Clean(reconstructed)
-
-		absClean := filepath.Clean(absolutePath)
-		if reconstructed != absClean {
-			return fmt.Errorf("path traversal detected: reconstructed path %s doesn't match original %s",
-				reconstructed, absClean)
-		}
-	}
-
-	// Ensure the relative path doesn't contain the base path (indicating calculation error)
-	if strings.Contains(relativePath, basePath) {
-		return fmt.Errorf("relative path contains base path: %s contains %s", relativePath, basePath)
-	}
-
-	// Verify the path is actually relative
-	if filepath.IsAbs(relativePath) {
-		return fmt.Errorf("calculated path is not relative: %s", relativePath)
-	}
-
-	return nil
 }
 
 // validateParseDirectoryInput validates the input parameters for ParseDirectory.

--- a/internal/adapter/outbound/treesitter/code_parser_test.go
+++ b/internal/adapter/outbound/treesitter/code_parser_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -511,5 +513,175 @@ type EmptyInterface interface{}
 		assert.NotEmpty(t, chunk.Language, "Chunk should have a language")
 		assert.NotZero(t, chunk.Size, "Chunk should have a size")
 		assert.NotEmpty(t, chunk.Hash, "Chunk should have a hash")
+	}
+}
+
+// chunkKey produces a stable sort key for a CodeChunk so that two parses of the
+// same directory can be compared regardless of order.
+func chunkKey(c outbound.CodeChunk) string {
+	return fmt.Sprintf("%s:%d:%s", c.FilePath, c.StartLine, c.Hash)
+}
+
+// sortedChunkKeys returns a sorted slice of chunkKey values for the given chunks.
+func sortedChunkKeys(chunks []outbound.CodeChunk) []string {
+	keys := make([]string, len(chunks))
+	for i, c := range chunks {
+		keys[i] = chunkKey(c)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// makeGoFiles creates n minimal .go source files under dir and returns their paths.
+func makeGoFiles(t *testing.T, dir string, n int) {
+	t.Helper()
+	for i := range n {
+		content := fmt.Sprintf(`package bench
+
+// Func%d is a generated function used in concurrency tests.
+func Func%d(x int) int {
+	return x * %d
+}
+`, i, i, i+1)
+		path := filepath.Join(dir, fmt.Sprintf("file%d.go", i))
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	}
+}
+
+// TestParseDirectory_ConcurrencyProducesIdenticalResults verifies that parsing with
+// ParseConcurrency=1 and ParseConcurrency=8 produces identical chunk sets.
+//
+// This test MUST FAIL initially because CodeParsingConfig does not yet have a
+// ParseConcurrency field.
+func TestParseDirectory_ConcurrencyProducesIdenticalResults(t *testing.T) {
+	t.Parallel()
+
+	const fileCount = 12
+
+	dir := t.TempDir()
+	makeGoFiles(t, dir, fileCount)
+
+	ctx := context.Background()
+	parser, err := NewTreeSitterCodeParser(ctx)
+	require.NoError(t, err)
+
+	baseConfig := outbound.CodeParsingConfig{
+		ChunkSizeBytes:   4096,
+		MaxFileSizeBytes: 1 << 20, // 1 MiB
+		IncludeTests:     true,
+		ExcludeVendor:    true,
+	}
+
+	// Parse serially (concurrency = 1).
+	serialConfig := baseConfig
+	serialConfig.ParseConcurrency = 1 // FAILS: field does not exist yet
+
+	serialChunks, err := parser.ParseDirectory(ctx, dir, serialConfig)
+	require.NoError(t, err, "serial parse (ParseConcurrency=1) should not error")
+	require.NotEmpty(t, serialChunks, "serial parse should return chunks")
+
+	// Parse in parallel (concurrency = 8).
+	parallelConfig := baseConfig
+	parallelConfig.ParseConcurrency = 8 // FAILS: field does not exist yet
+
+	parallelChunks, err := parser.ParseDirectory(ctx, dir, parallelConfig)
+	require.NoError(t, err, "parallel parse (ParseConcurrency=8) should not error")
+	require.NotEmpty(t, parallelChunks, "parallel parse should return chunks")
+
+	// The chunk sets must be identical when sorted by (FilePath, StartLine, Hash).
+	assert.Equal(t,
+		sortedChunkKeys(serialChunks),
+		sortedChunkKeys(parallelChunks),
+		"ParseDirectory with ParseConcurrency=1 and ParseConcurrency=8 must produce identical chunk sets",
+	)
+}
+
+// TestParseDirectory_DefaultConcurrency verifies that ParseDirectory works correctly
+// when ParseConcurrency=0, which should default to runtime.GOMAXPROCS(0) workers.
+//
+// This test MUST FAIL initially because CodeParsingConfig does not yet have a
+// ParseConcurrency field.
+func TestParseDirectory_DefaultConcurrency(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	makeGoFiles(t, dir, 5)
+
+	ctx := context.Background()
+	parser, err := NewTreeSitterCodeParser(ctx)
+	require.NoError(t, err)
+
+	config := outbound.CodeParsingConfig{
+		ChunkSizeBytes:   4096,
+		MaxFileSizeBytes: 1 << 20,
+		IncludeTests:     true,
+		ExcludeVendor:    true,
+		ParseConcurrency: 0, // FAILS: field does not exist yet; 0 should mean GOMAXPROCS
+	}
+
+	// Sanity-check that GOMAXPROCS is positive so the test assumption holds.
+	require.Positive(t, runtime.GOMAXPROCS(0),
+		"GOMAXPROCS must be positive for default concurrency to be meaningful")
+
+	chunks, err := parser.ParseDirectory(ctx, dir, config)
+	require.NoError(t, err, "ParseDirectory with ParseConcurrency=0 (default GOMAXPROCS) must not error")
+	require.NotEmpty(t, chunks, "ParseDirectory with default concurrency must return chunks")
+}
+
+// makeBenchGoFiles creates n minimal .go source files under dir for benchmarks.
+func makeBenchGoFiles(b *testing.B, dir string, n int) {
+	b.Helper()
+	for i := range n {
+		content := fmt.Sprintf(`package bench
+
+// Func%d is a generated benchmark function.
+func Func%d(x int) int { return x * %d }
+`, i, i, i+1)
+		path := filepath.Join(dir, fmt.Sprintf("file%d.go", i))
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkParseDirectory_Serial benchmarks ParseDirectory with a single worker.
+func BenchmarkParseDirectory_Serial(b *testing.B) {
+	dir := b.TempDir()
+	makeBenchGoFiles(b, dir, 50)
+	ctx := context.Background()
+	p, err := NewTreeSitterCodeParser(ctx)
+	if err != nil {
+		b.Fatal(err)
+	}
+	cfg := outbound.CodeParsingConfig{
+		ChunkSizeBytes: 4096, MaxFileSizeBytes: 1 << 20,
+		IncludeTests: true, ExcludeVendor: true, ParseConcurrency: 1,
+	}
+	b.ResetTimer()
+	for b.Loop() {
+		if _, err := p.ParseDirectory(ctx, dir, cfg); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkParseDirectory_Parallel benchmarks ParseDirectory with GOMAXPROCS workers.
+func BenchmarkParseDirectory_Parallel(b *testing.B) {
+	dir := b.TempDir()
+	makeBenchGoFiles(b, dir, 50)
+	ctx := context.Background()
+	p, err := NewTreeSitterCodeParser(ctx)
+	if err != nil {
+		b.Fatal(err)
+	}
+	cfg := outbound.CodeParsingConfig{
+		ChunkSizeBytes: 4096, MaxFileSizeBytes: 1 << 20,
+		IncludeTests: true, ExcludeVendor: true, ParseConcurrency: 0,
+	}
+	b.ResetTimer()
+	for b.Loop() {
+		if _, err := p.ParseDirectory(ctx, dir, cfg); err != nil {
+			b.Fatal(err)
+		}
 	}
 }

--- a/internal/adapter/outbound/treesitter/errors/go_validator.go
+++ b/internal/adapter/outbound/treesitter/errors/go_validator.go
@@ -1,13 +1,14 @@
 package parsererrors
 
 import (
+	"codechunking/internal/adapter/outbound/treesitter"
 	"codechunking/internal/domain/valueobject"
 	"context"
 	"errors"
+	"fmt"
 	"regexp"
 	"strings"
 
-	forest "github.com/alexaandru/go-sitter-forest"
 	tree_sitter "github.com/alexaandru/go-tree-sitter-bare"
 )
 
@@ -120,20 +121,11 @@ func (v *GoValidator) createParseTreeWithoutValidation(ctx context.Context, sour
 	// For snippets without package declarations, wrap them to avoid ERROR nodes
 	wrappedSource, isWrapped := v.wrapSnippetIfNeeded(source)
 
-	// Use direct tree-sitter parsing without going through the validation layer
-	grammar := forest.GetLanguage("go")
-	if grammar == nil {
+	parser, parserErr := treesitter.GetCachedParser("go")
+	if parserErr != nil {
 		return nil
 	}
-
-	parser := tree_sitter.NewParser()
-	if parser == nil {
-		return nil
-	}
-
-	if ok := parser.SetLanguage(grammar); !ok {
-		return nil
-	}
+	defer treesitter.PutCachedParser("go", parser)
 
 	tree, err := parser.ParseString(ctx, nil, []byte(wrappedSource))
 	if err != nil {
@@ -587,6 +579,8 @@ func (v *GoValidator) validateSyntaxErrorNodes(parseTree *valueobject.ParseTree)
 }
 
 // analyzeErrorForSpecificPattern examines an ERROR node for specific patterns.
+//
+//nolint:gocognit // complex pattern matching requires multiple branches
 func analyzeErrorForSpecificPattern(errorNode *valueobject.ParseNode, parseTree *valueobject.ParseTree) string {
 	if errorNode == nil || parseTree == nil {
 		return "syntax error detected by tree-sitter parser"
@@ -1083,22 +1077,15 @@ type ComprehensiveErrorDetectionResult struct {
 // parseTreeWithTreeSitter parses source code using tree-sitter and returns the raw tree.
 // This is a common helper method to avoid duplicating tree-sitter setup code.
 func (v *GoValidator) parseTreeWithTreeSitter(source string) (*tree_sitter.Tree, error) {
-	grammar := forest.GetLanguage("go")
-	if grammar == nil {
-		return nil, errors.New("tree-sitter Go grammar not available")
-	}
-
-	parser := tree_sitter.NewParser()
-	if parser == nil {
-		return nil, errors.New("failed to create tree-sitter parser")
-	}
-
-	if ok := parser.SetLanguage(grammar); !ok {
-		return nil, errors.New("failed to set Go language for parser")
+	parser, err := treesitter.GetCachedParser("go")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cached parser: %w", err)
 	}
 
 	ctx := context.Background()
 	tree, err := parser.ParseString(ctx, nil, []byte(source))
+	// Return parser to pool immediately — tree-sitter trees are self-contained after ParseString.
+	treesitter.PutCachedParser("go", parser)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/adapter/outbound/treesitter/parser_factory.go
+++ b/internal/adapter/outbound/treesitter/parser_factory.go
@@ -8,6 +8,9 @@ import (
 	"fmt"
 	"sync"
 	"time"
+
+	forest "github.com/alexaandru/go-sitter-forest"
+	tree_sitter "github.com/alexaandru/go-tree-sitter-bare"
 )
 
 // ParserFactoryImpl implements TreeSitterParserFactory using go-sitter-forest.
@@ -493,4 +496,68 @@ func GetRegisteredLanguages() []string {
 		languages = append(languages, lang)
 	}
 	return languages
+}
+
+// ============================================================================
+// Per-language sync.Pool for tree-sitter parsers
+// ============================================================================
+
+//nolint:gochecknoglobals // pool map requires global access for cross-goroutine reuse
+var parserPools sync.Map // map[string]*sync.Pool
+
+// GetCachedParser retrieves a pooled *tree_sitter.Parser pre-configured for
+// languageName, allocating a fresh one when the pool is empty.
+func GetCachedParser(languageName string) (*tree_sitter.Parser, error) {
+	pool := getOrCreateParserPool(languageName)
+	if p, ok := pool.Get().(*tree_sitter.Parser); ok && p != nil {
+		return p, nil
+	}
+	return newParserForLanguage(languageName)
+}
+
+// PutCachedParser returns a parser to its pool for reuse.
+// Reset is called first to clear any cancellation or partial-parse state left
+// by a previous context timeout or interruption, as the tree-sitter docs
+// require Reset before parsing a different document after an interruption.
+func PutCachedParser(languageName string, p *tree_sitter.Parser) {
+	if p == nil {
+		return
+	}
+	p.Reset()
+	pool := getOrCreateParserPool(languageName)
+	pool.Put(p)
+}
+
+func getOrCreateParserPool(languageName string) *sync.Pool {
+	if v, ok := parserPools.Load(languageName); ok {
+		p, _ := v.(*sync.Pool)
+		return p
+	}
+	newPool := &sync.Pool{
+		New: func() any {
+			p, err := newParserForLanguage(languageName)
+			if err != nil {
+				return nil
+			}
+			return p
+		},
+	}
+	actual, _ := parserPools.LoadOrStore(languageName, newPool)
+	p, _ := actual.(*sync.Pool)
+	return p
+}
+
+func newParserForLanguage(languageName string) (*tree_sitter.Parser, error) {
+	grammar := forest.GetLanguage(languageName)
+	if grammar == nil {
+		return nil, fmt.Errorf("no grammar available for language: %s", languageName)
+	}
+	p := tree_sitter.NewParser()
+	if p == nil {
+		return nil, fmt.Errorf("failed to allocate tree-sitter parser for: %s", languageName)
+	}
+	if !p.SetLanguage(grammar) {
+		return nil, fmt.Errorf("failed to set language %s on parser", languageName)
+	}
+	return p, nil
 }

--- a/internal/adapter/outbound/treesitter/parsers/go/go_parser.go
+++ b/internal/adapter/outbound/treesitter/parsers/go/go_parser.go
@@ -16,7 +16,6 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	forest "github.com/alexaandru/go-sitter-forest"
 	tree_sitter "github.com/alexaandru/go-tree-sitter-bare"
 )
 
@@ -104,19 +103,11 @@ func (p *GoParser) Parse(ctx context.Context, sourceCode string) (*valueobject.P
 		return nil, err
 	}
 
-	grammar := forest.GetLanguage("go")
-	if grammar == nil {
-		return nil, errors.New("failed to get Go grammar from forest")
+	parser, err := treesitter.GetCachedParser("go")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cached parser: %w", err)
 	}
-
-	parser := tree_sitter.NewParser()
-	if parser == nil {
-		return nil, errors.New("failed to create tree-sitter parser")
-	}
-
-	if ok := parser.SetLanguage(grammar); !ok {
-		return nil, errors.New("failed to set Go language in tree-sitter parser")
-	}
+	defer treesitter.PutCachedParser("go", parser)
 
 	tree, err := parser.ParseString(ctx, nil, source)
 	if err != nil {
@@ -673,21 +664,11 @@ func parseWithDirectTreeSitter(source string) *valueobject.ParseTree {
 		sourceBytes = []byte(" ")
 	}
 
-	// Get Go grammar directly
-	grammar := forest.GetLanguage("go")
-	if grammar == nil {
+	parser, parserErr := treesitter.GetCachedParser("go")
+	if parserErr != nil {
 		return nil
 	}
-
-	// Create parser without going through factory/validation
-	parser := tree_sitter.NewParser()
-	if parser == nil {
-		return nil
-	}
-
-	if ok := parser.SetLanguage(grammar); !ok {
-		return nil
-	}
+	defer treesitter.PutCachedParser("go", parser)
 
 	// Parse directly without validation
 	tree, err := parser.ParseString(ctx, nil, sourceBytes)
@@ -1456,6 +1437,24 @@ func containsErrorNodesInSubtree(node *valueobject.ParseNode) bool {
 // isValidGoIdentifier checks if a string is a valid Go identifier based on tree-sitter grammar rules.
 // Go identifier pattern (from tree-sitter-go): [_\p{XID_Start}][_\p{XID_Continue}]*
 // This means: starts with underscore or letter (including Unicode), followed by underscores, letters, or digits.
+// isRepeatedFieldPattern checks whether parts represents a sequence of repeated
+// "identifier type" pairs (e.g. stress-test inputs like "Name string Name string …").
+// It samples up to the first 10 pairs for efficiency.
+func isRepeatedFieldPattern(parts []string) bool {
+	if len(parts)%2 != 0 {
+		return false
+	}
+	samplesToCheck := min(10, len(parts)/2)
+	for i := range samplesToCheck {
+		nameIdx := i * 2
+		typeIdx := nameIdx + 1
+		if !isValidGoIdentifier(parts[nameIdx]) || !isValidGoIdentifier(parts[typeIdx]) {
+			return false
+		}
+	}
+	return true
+}
+
 func isValidGoIdentifier(s string) bool {
 	if s == "" {
 		return false
@@ -1580,28 +1579,7 @@ func isMinimalFieldPattern(trimmed string) bool {
 	// Example: "Name string Name string Name string..." (1000 times)
 	// This prevents false rejection of stress test inputs
 	if len(parts) > 3 {
-		// Check if this appears to be a repeated field pattern (pairs of identifier + type)
-		// We'll sample the first few pairs to validate the pattern
-		if len(parts)%2 == 0 {
-			// Even number of parts - could be repeated "Name string" pattern
-			allPairsValid := true
-			samplesToCheck := min(10, len(parts)/2) // Check first 10 pairs or fewer
-
-			for i := range samplesToCheck {
-				nameIdx := i * 2
-				typeIdx := nameIdx + 1
-
-				if !isValidGoIdentifier(parts[nameIdx]) || !isValidGoIdentifier(parts[typeIdx]) {
-					allPairsValid = false
-					break
-				}
-			}
-
-			if allPairsValid {
-				return true // Repeated valid field pattern
-			}
-		}
-		return false // Too many parts and not a recognized pattern
+		return isRepeatedFieldPattern(parts)
 	}
 
 	// Validate the first part is a valid Go identifier (field name or embedded type)
@@ -1681,18 +1659,11 @@ func (o *ObservableGoParser) Parse(ctx context.Context, source []byte) (*treesit
 		return nil, err
 	}
 
-	grammar := forest.GetLanguage("go")
-	if grammar == nil {
-		return nil, errors.New("failed to get Go grammar from forest")
+	parser, err := treesitter.GetCachedParser("go")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cached parser: %w", err)
 	}
-
-	parser := tree_sitter.NewParser()
-	if parser == nil {
-		return nil, errors.New("failed to create tree-sitter parser")
-	}
-	if ok := parser.SetLanguage(grammar); !ok {
-		return nil, errors.New("failed to set Go language in tree-sitter parser")
-	}
+	defer treesitter.PutCachedParser("go", parser)
 
 	tree, err := parser.ParseString(ctx, nil, source)
 	if err != nil {
@@ -1753,18 +1724,11 @@ func (o *ObservableGoParser) ParseSource(
 		return nil, err
 	}
 
-	grammar := forest.GetLanguage("go")
-	if grammar == nil {
-		return nil, errors.New("failed to get Go grammar from forest")
+	parser, err := treesitter.GetCachedParser("go")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cached parser: %w", err)
 	}
-
-	parser := tree_sitter.NewParser()
-	if parser == nil {
-		return nil, errors.New("failed to create tree-sitter parser")
-	}
-	if ok := parser.SetLanguage(grammar); !ok {
-		return nil, errors.New("failed to set Go language in tree-sitter parser")
-	}
+	defer treesitter.PutCachedParser("go", parser)
 
 	tree, err := parser.ParseString(ctx, nil, source)
 	if err != nil {
@@ -2827,18 +2791,8 @@ func (p *GoParser) detectErrorsWithNativeMethods(sourceCode string) *ErrorDetect
 	ctx := context.Background()
 
 	// Parse directly with tree-sitter to access native error detection
-	grammar := forest.GetLanguage("go")
-	if grammar == nil {
-		return &ErrorDetectionResult{
-			HasError:       true,
-			IsError:        true,
-			IsMissing:      false,
-			ErrorNodeTypes: []string{"GRAMMAR_ERROR"},
-		}
-	}
-
-	parser := tree_sitter.NewParser()
-	if parser == nil {
+	parser, parserErr := treesitter.GetCachedParser("go")
+	if parserErr != nil {
 		return &ErrorDetectionResult{
 			HasError:       true,
 			IsError:        true,
@@ -2846,15 +2800,7 @@ func (p *GoParser) detectErrorsWithNativeMethods(sourceCode string) *ErrorDetect
 			ErrorNodeTypes: []string{"PARSER_ERROR"},
 		}
 	}
-
-	if ok := parser.SetLanguage(grammar); !ok {
-		return &ErrorDetectionResult{
-			HasError:       true,
-			IsError:        true,
-			IsMissing:      false,
-			ErrorNodeTypes: []string{"LANGUAGE_ERROR"},
-		}
-	}
+	defer treesitter.PutCachedParser("go", parser)
 
 	tree, err := parser.ParseString(ctx, nil, []byte(sourceCode))
 	if err != nil {
@@ -2956,32 +2902,11 @@ type RealAPIResult struct {
 // detectSpecificSyntaxErrors analyzes source code for specific syntax error patterns
 // using tree-sitter's native error detection methods (HasError, IsError, IsMissing).
 func (p *GoParser) detectSpecificSyntaxErrors(sourceCode string) *SpecificSyntaxErrorResult {
-	// Parse with tree-sitter
-	grammar := forest.GetLanguage("go")
-	if grammar == nil {
-		return &SpecificSyntaxErrorResult{
-			HasSyntaxError: false,
-			ErrorType:      "",
-			ErrorLocation:  "",
-			RecoveryHint:   "",
-			UsedHasError:   false,
-			UsedIsError:    false,
-			UsedIsMissing:  false,
-		}
+	parser, parserErr := treesitter.GetCachedParser("go")
+	if parserErr != nil {
+		return &SpecificSyntaxErrorResult{HasSyntaxError: false}
 	}
-
-	parser := tree_sitter.NewParser()
-	if parser == nil {
-		return &SpecificSyntaxErrorResult{
-			HasSyntaxError: false,
-		}
-	}
-
-	if ok := parser.SetLanguage(grammar); !ok {
-		return &SpecificSyntaxErrorResult{
-			HasSyntaxError: false,
-		}
-	}
+	defer treesitter.PutCachedParser("go", parser)
 
 	tree, err := parser.ParseString(context.Background(), nil, []byte(sourceCode))
 	if err != nil || tree == nil {
@@ -3146,34 +3071,14 @@ func classifyMissingNode(node tree_sitter.Node, sourceCode string) (string, stri
 
 // validateWithRealTreeSitterAPI validates source code using the actual tree-sitter API.
 func (p *GoParser) validateWithRealTreeSitterAPI(ctx context.Context, sourceCode string) *RealAPIResult {
-	grammar := forest.GetLanguage("go")
-	if grammar == nil {
+	parser, parserErr := treesitter.GetCachedParser("go")
+	if parserErr != nil {
 		return &RealAPIResult{
-			Error:          errors.New("failed to get Go grammar from forest"),
-			CalledHasError: false,
-			ParseTree:      nil,
-			UsedNativeAPI:  false,
+			Error:         parserErr,
+			UsedNativeAPI: false,
 		}
 	}
-
-	parser := tree_sitter.NewParser()
-	if parser == nil {
-		return &RealAPIResult{
-			Error:          errors.New("failed to create tree-sitter parser"),
-			CalledHasError: false,
-			ParseTree:      nil,
-			UsedNativeAPI:  false,
-		}
-	}
-
-	if ok := parser.SetLanguage(grammar); !ok {
-		return &RealAPIResult{
-			Error:          errors.New("failed to set Go language in tree-sitter parser"),
-			CalledHasError: false,
-			ParseTree:      nil,
-			UsedNativeAPI:  false,
-		}
-	}
+	defer treesitter.PutCachedParser("go", parser)
 
 	tree, err := parser.ParseString(ctx, nil, []byte(sourceCode))
 	if err != nil {

--- a/internal/adapter/outbound/treesitter/parsers/javascript/javascript_parser.go
+++ b/internal/adapter/outbound/treesitter/parsers/javascript/javascript_parser.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	forest "github.com/alexaandru/go-sitter-forest"
 	tree_sitter "github.com/alexaandru/go-tree-sitter-bare"
 )
 
@@ -56,23 +55,11 @@ func (o *ObservableJavaScriptParser) Parse(ctx context.Context, source []byte) (
 		return nil, err
 	}
 
-	// Get JavaScript grammar from forest
-	grammar := forest.GetLanguage("javascript")
-	if grammar == nil {
-		return nil, errors.New("failed to get JavaScript grammar from forest")
+	parser, err := treesitter.GetCachedParser("javascript")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cached parser: %w", err)
 	}
-
-	// Create tree-sitter parser
-	parser := tree_sitter.NewParser()
-	if parser == nil {
-		return nil, errors.New("failed to create tree-sitter parser")
-	}
-
-	// Set language
-	success := parser.SetLanguage(grammar)
-	if !success {
-		return nil, errors.New("failed to set JavaScript language")
-	}
+	defer treesitter.PutCachedParser("javascript", parser)
 
 	// Parse the source code
 	tree, err := parser.ParseString(ctx, nil, source)
@@ -128,23 +115,11 @@ func (o *ObservableJavaScriptParser) ParseSource(
 ) (*treesitter.ParseResult, error) {
 	start := time.Now()
 
-	// Get JavaScript grammar from forest
-	grammar := forest.GetLanguage("javascript")
-	if grammar == nil {
-		return nil, errors.New("failed to get JavaScript grammar from forest")
+	parser, err := treesitter.GetCachedParser("javascript")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cached parser: %w", err)
 	}
-
-	// Create tree-sitter parser
-	parser := tree_sitter.NewParser()
-	if parser == nil {
-		return nil, errors.New("failed to create tree-sitter parser")
-	}
-
-	// Set language
-	success := parser.SetLanguage(grammar)
-	if !success {
-		return nil, errors.New("failed to set JavaScript language")
-	}
+	defer treesitter.PutCachedParser("javascript", parser)
 
 	// Parse the source code
 	tree, err := parser.ParseString(ctx, nil, source)
@@ -207,20 +182,11 @@ func (o *ObservableJavaScriptParser) Close() error {
 
 // validateJavaScriptSource performs comprehensive validation of JavaScript source code using tree-sitter.
 func (p *JavaScriptParser) validateJavaScriptSource(ctx context.Context, source []byte) error {
-	// Parse with tree-sitter first to get the AST
-	grammar := forest.GetLanguage("javascript")
-	if grammar == nil {
-		return errors.New("failed to get JavaScript grammar")
+	parser, err := treesitter.GetCachedParser("javascript")
+	if err != nil {
+		return fmt.Errorf("failed to get cached parser: %w", err)
 	}
-
-	parser := tree_sitter.NewParser()
-	if parser == nil {
-		return errors.New("failed to create tree-sitter parser")
-	}
-
-	if !parser.SetLanguage(grammar) {
-		return errors.New("failed to set JavaScript language")
-	}
+	defer treesitter.PutCachedParser("javascript", parser)
 
 	tree, err := parser.ParseString(ctx, nil, source)
 	if err != nil {

--- a/internal/adapter/outbound/treesitter/parsers/javascript/jsdoc.go
+++ b/internal/adapter/outbound/treesitter/parsers/javascript/jsdoc.go
@@ -1,12 +1,12 @@
 package javascriptparser
 
 import (
+	"codechunking/internal/adapter/outbound/treesitter"
 	"codechunking/internal/domain/valueobject"
 	"codechunking/internal/port/outbound"
 	"context"
 	"strings"
 
-	forest "github.com/alexaandru/go-sitter-forest"
 	tree_sitter "github.com/alexaandru/go-tree-sitter-bare"
 )
 
@@ -60,9 +60,9 @@ func findJSDocComment(parseTree *valueobject.ParseTree, targetNode *valueobject.
 
 	// Calculate absolute byte positions.
 	// jsdocStart and jsdocEnd are bounded by beforeFunction length (max 500 bytes),
-	// so they are safe to convert to uint32.
-	absoluteStart := searchStart + uint32(jsdocStart)
-	absoluteEnd := searchStart + uint32(jsdocStart+jsdocEnd+2)
+	// so the int→uint32 conversion is safe.
+	absoluteStart := searchStart + uint32(jsdocStart)          //nolint:gosec // bounded by 500-byte window
+	absoluteEnd := searchStart + uint32(jsdocStart+jsdocEnd+2) //nolint:gosec // bounded by 500-byte window
 
 	// Create a synthetic ParseNode for the comment
 	// (This is a simplified approach - ideally we'd find the actual comment node from the tree)
@@ -79,22 +79,11 @@ func findJSDocComment(parseTree *valueobject.ParseTree, targetNode *valueobject.
 func parseJSDocComment(commentText string) *JSDocInfo {
 	ctx := context.Background()
 
-	// Get JSDoc grammar
-	grammar := forest.GetLanguage("jsdoc")
-	if grammar == nil {
+	parser, parserErr := treesitter.GetCachedParser("jsdoc")
+	if parserErr != nil {
 		return nil
 	}
-
-	// Create parser
-	parser := tree_sitter.NewParser()
-	if parser == nil {
-		return nil
-	}
-
-	// Set language
-	if !parser.SetLanguage(grammar) {
-		return nil
-	}
+	defer treesitter.PutCachedParser("jsdoc", parser)
 
 	// Parse the comment
 	tree, err := parser.ParseString(ctx, nil, []byte(commentText))

--- a/internal/application/service/duplicate_detection_service_test.go
+++ b/internal/application/service/duplicate_detection_service_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 	"time"
 
-	domainerrors "codechunking/internal/domain/errors/domain"
-
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -101,15 +99,13 @@ func (m *MockRepositoryRepositoryWithNormalization) Exists(
 	return args.Bool(0), args.Error(1)
 }
 
-// TestCreateRepositoryService_DetectDuplicatesByNormalizedURL tests duplicate detection using normalized URLs
-// This test will FAIL initially as normalized duplicate detection doesn't exist yet.
+// TestCreateRepositoryService_DetectDuplicatesByNormalizedURL tests duplicate detection using normalized URLs.
 func TestCreateRepositoryService_DetectDuplicatesByNormalizedURL(t *testing.T) {
 	tests := []struct {
 		name                  string
 		existingURL           string
 		newURL                string
 		shouldDetectDuplicate bool
-		expectedError         error
 		description           string
 	}{
 		{
@@ -117,7 +113,6 @@ func TestCreateRepositoryService_DetectDuplicatesByNormalizedURL(t *testing.T) {
 			existingURL:           "https://github.com/owner/repo",
 			newURL:                "https://github.com/owner/repo.git",
 			shouldDetectDuplicate: true,
-			expectedError:         domainerrors.ErrRepositoryAlreadyExists,
 			description:           "Should detect duplicate when new URL has .git suffix but existing doesn't",
 		},
 		{
@@ -125,7 +120,6 @@ func TestCreateRepositoryService_DetectDuplicatesByNormalizedURL(t *testing.T) {
 			existingURL:           "https://github.com/owner/repo",
 			newURL:                "https://GitHub.com/owner/repo",
 			shouldDetectDuplicate: true,
-			expectedError:         domainerrors.ErrRepositoryAlreadyExists,
 			description:           "Should detect duplicate when hostname case differs",
 		},
 		{
@@ -133,7 +127,6 @@ func TestCreateRepositoryService_DetectDuplicatesByNormalizedURL(t *testing.T) {
 			existingURL:           "https://github.com/owner/repo",
 			newURL:                "http://github.com/owner/repo",
 			shouldDetectDuplicate: true,
-			expectedError:         domainerrors.ErrRepositoryAlreadyExists,
 			description:           "Should detect duplicate when protocol differs (http vs https)",
 		},
 		{
@@ -141,7 +134,6 @@ func TestCreateRepositoryService_DetectDuplicatesByNormalizedURL(t *testing.T) {
 			existingURL:           "https://github.com/owner/repo",
 			newURL:                "https://github.com/owner/repo/",
 			shouldDetectDuplicate: true,
-			expectedError:         domainerrors.ErrRepositoryAlreadyExists,
 			description:           "Should detect duplicate when new URL has trailing slash",
 		},
 		{
@@ -149,7 +141,6 @@ func TestCreateRepositoryService_DetectDuplicatesByNormalizedURL(t *testing.T) {
 			existingURL:           "https://github.com/owner/repo",
 			newURL:                "https://github.com/owner/repo?branch=main",
 			shouldDetectDuplicate: true,
-			expectedError:         domainerrors.ErrRepositoryAlreadyExists,
 			description:           "Should detect duplicate when new URL has query parameters",
 		},
 		{
@@ -157,7 +148,6 @@ func TestCreateRepositoryService_DetectDuplicatesByNormalizedURL(t *testing.T) {
 			existingURL:           "https://github.com/owner/repo",
 			newURL:                "https://github.com/owner/repo#readme",
 			shouldDetectDuplicate: true,
-			expectedError:         domainerrors.ErrRepositoryAlreadyExists,
 			description:           "Should detect duplicate when new URL has fragment identifier",
 		},
 		{
@@ -165,7 +155,6 @@ func TestCreateRepositoryService_DetectDuplicatesByNormalizedURL(t *testing.T) {
 			existingURL:           "https://github.com/owner/repo",
 			newURL:                "HTTP://GitHub.COM/owner/repo.git/?branch=main#readme///",
 			shouldDetectDuplicate: true,
-			expectedError:         domainerrors.ErrRepositoryAlreadyExists,
 			description:           "Should detect duplicate with complex URL variations",
 		},
 		{
@@ -173,7 +162,6 @@ func TestCreateRepositoryService_DetectDuplicatesByNormalizedURL(t *testing.T) {
 			existingURL:           "https://github.com/owner/repo1",
 			newURL:                "https://github.com/owner/repo2",
 			shouldDetectDuplicate: false,
-			expectedError:         nil,
 			description:           "Should allow different repositories from same owner",
 		},
 		{
@@ -181,7 +169,6 @@ func TestCreateRepositoryService_DetectDuplicatesByNormalizedURL(t *testing.T) {
 			existingURL:           "https://github.com/owner1/repo",
 			newURL:                "https://github.com/owner2/repo",
 			shouldDetectDuplicate: false,
-			expectedError:         nil,
 			description:           "Should allow same repository name with different owner",
 		},
 		{
@@ -189,7 +176,6 @@ func TestCreateRepositoryService_DetectDuplicatesByNormalizedURL(t *testing.T) {
 			existingURL:           "https://github.com/owner/repo",
 			newURL:                "https://gitlab.com/owner/repo",
 			shouldDetectDuplicate: false,
-			expectedError:         nil,
 			description:           "Should allow same repo name on different hosting providers",
 		},
 	}
@@ -202,16 +188,22 @@ func TestCreateRepositoryService_DetectDuplicatesByNormalizedURL(t *testing.T) {
 			mockJobRepo := new(MockIndexingJobRepository)
 			mockPublisher := &MockMessagePublisher{}
 
-			// Create service with enhanced duplicate detection - this will FAIL as the service doesn't use normalization yet
 			service := NewCreateRepositoryServiceWithNormalizedDuplicateDetection(mockRepo, mockJobRepo, mockPublisher)
 
 			// Setup mocks based on expected behavior
 			if tt.shouldDetectDuplicate {
-				// Mock should return true for duplicate check (the service uses regular Exists)
-				mockRepo.On("Exists", ctx, mock.AnythingOfType("valueobject.RepositoryURL")).Return(true, nil)
+				// Mock finding existing repository
+				existingURL, _ := valueobject.NewRepositoryURL(tt.existingURL)
+				existingRepo := entity.NewRepository(existingURL, "existing", nil, nil)
+				mockRepo.On("FindByNormalizedURL", ctx, mock.AnythingOfType("valueobject.RepositoryURL")).Return(existingRepo, nil)
+
+				// For duplicate, expect status reset (Update) and job publication
+				mockRepo.On("Update", ctx, mock.AnythingOfType("*entity.Repository")).Return(nil)
+				mockJobRepo.On("Save", ctx, mock.AnythingOfType("*entity.IndexingJob")).Return(nil)
+				mockPublisher.On("PublishIndexingJob", ctx, mock.AnythingOfType("uuid.UUID"), mock.AnythingOfType("uuid.UUID"), mock.AnythingOfType("string")).Return(nil)
 			} else {
-				// Mock should return false (no duplicate found)
-				mockRepo.On("Exists", ctx, mock.AnythingOfType("valueobject.RepositoryURL")).Return(false, nil)
+				// Mock not finding repository
+				mockRepo.On("FindByNormalizedURL", ctx, mock.AnythingOfType("valueobject.RepositoryURL")).Return(nil, nil)
 				// If no duplicate, expect save and publish calls
 				mockRepo.On("Save", ctx, mock.AnythingOfType("*entity.Repository")).Return(nil)
 				mockJobRepo.On("Save", ctx, mock.AnythingOfType("*entity.IndexingJob")).Return(nil)
@@ -228,14 +220,13 @@ func TestCreateRepositoryService_DetectDuplicatesByNormalizedURL(t *testing.T) {
 			response, err := service.CreateRepository(ctx, request)
 
 			// Verify
+			require.NoError(t, err, tt.description)
+			assert.NotNil(t, response, "Response should not be nil")
+
 			if tt.shouldDetectDuplicate {
-				require.Error(t, err, tt.description)
-				assert.Equal(t, tt.expectedError, err, tt.description)
-				assert.Nil(t, response, "Response should be nil when duplicate is detected")
+				assert.Equal(t, "existing", response.Name, "Should return existing repository")
 			} else {
-				require.NoError(t, err, tt.description)
-				assert.NotNil(t, response, "Response should not be nil when repository is created successfully")
-				assert.Equal(t, "test-repo", response.Name, "Response should contain correct repository name")
+				assert.Equal(t, "test-repo", response.Name, "Should return new repository")
 			}
 
 			// Verify mock expectations
@@ -258,7 +249,7 @@ func TestCreateRepositoryService_NormalizedDuplicateDetectionWithDatabaseError(t
 
 	// Setup mock to return database error
 	expectedError := errors.New("database connection failed")
-	mockRepo.On("Exists", ctx, mock.AnythingOfType("valueobject.RepositoryURL")).Return(false, expectedError)
+	mockRepo.On("FindByNormalizedURL", ctx, mock.AnythingOfType("valueobject.RepositoryURL")).Return(nil, expectedError)
 
 	// Execute
 	request := dto.CreateRepositoryRequest{

--- a/internal/application/service/repository_service.go
+++ b/internal/application/service/repository_service.go
@@ -75,8 +75,8 @@ func NewCreateRepositoryServiceWithNormalizedDuplicateDetection(
 }
 
 // CreateRepository creates a new repository and publishes an indexing job.
-// It validates the repository URL, ensures it doesn't already exist, creates the entity,
-// saves it to the repository, publishes an indexing job, and returns the response.
+// It validates the repository URL, handles existing repositories by triggering a re-index,
+// creates the entity if new, saves it, and publishes an indexing job.
 func (s *CreateRepositoryService) CreateRepository(
 	ctx context.Context,
 	request dto.CreateRepositoryRequest,
@@ -91,25 +91,51 @@ func (s *CreateRepositoryService) CreateRepository(
 		return nil, err
 	}
 
-	// Check if repository already exists
-	if err := s.checkRepositoryExists(ctx, repositoryURL); err != nil {
-		return nil, err
-	}
-
-	// Create and save repository
-	repository, err := s.createAndSaveRepository(ctx, request, repositoryURL)
+	// Check if repository already exists by normalized URL for idempotent re-indexing
+	existingRepo, err := s.repositoryRepo.FindByNormalizedURL(ctx, repositoryURL)
 	if err != nil {
-		return nil, err
+		slogger.Error(ctx, "DEBUG: Failed to check for existing repository", slogger.Fields{
+			"normalized_url": repositoryURL.String(), "error": err.Error(),
+		})
+		return nil, common.WrapServiceError(common.OpCheckRepositoryExists, err)
 	}
 
-	// Publish indexing job
+	var repository *entity.Repository
+	if existingRepo != nil {
+		slogger.Info(ctx, "DEBUG: Repository already exists, resetting status for re-index", slogger.Fields{
+			"normalized_url": repositoryURL.String(),
+			"repository_id":  existingRepo.ID().String(),
+		})
+		if err := existingRepo.ResetForReindexing(); err != nil {
+			slogger.Error(ctx, "DEBUG: Failed to reset repository for re-indexing", slogger.Fields{
+				"repository_id": existingRepo.ID().String(), "error": err.Error(),
+			})
+			return nil, common.WrapServiceError(common.OpUpdateRepository, err)
+		}
+		if err := s.repositoryRepo.Update(ctx, existingRepo); err != nil {
+			slogger.Error(ctx, "DEBUG: Failed to save repository after reset", slogger.Fields{
+				"repository_id": existingRepo.ID().String(), "error": err.Error(),
+			})
+			return nil, common.WrapServiceError(common.OpSaveRepository, err)
+		}
+		repository = existingRepo
+	} else {
+		// Create and save new repository
+		repository, err = s.createAndSaveRepository(ctx, request, repositoryURL)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Publish indexing job (new or re-index)
 	if err := s.publishIndexingJob(ctx, repository, repositoryURL.CloneURL()); err != nil {
 		return nil, err
 	}
 
 	response := common.EntityToRepositoryResponse(repository)
-	slogger.Info(ctx, "DEBUG: Repository creation completed successfully", slogger.Fields{
+	slogger.Info(ctx, "DEBUG: Repository processing completed successfully", slogger.Fields{
 		"repository_id": repository.ID().String(), "name": repository.Name(),
+		"is_reindex": existingRepo != nil,
 	})
 	return response, nil
 }
@@ -130,30 +156,6 @@ func (s *CreateRepositoryService) validateRepositoryURL(
 		"normalized_url": repositoryURL.String(),
 	})
 	return repositoryURL, nil
-}
-
-// checkRepositoryExists verifies that a repository doesn't already exist.
-func (s *CreateRepositoryService) checkRepositoryExists(ctx context.Context, url valueobject.RepositoryURL) error {
-	slogger.Info(ctx, "DEBUG: Checking if repository exists", slogger.Fields{
-		"normalized_url": url.String(),
-	})
-	exists, err := s.repositoryRepo.Exists(ctx, url)
-	if err != nil {
-		slogger.Error(ctx, "DEBUG: Failed to check repository existence", slogger.Fields{
-			"normalized_url": url.String(), "error": err.Error(),
-		})
-		return common.WrapServiceError(common.OpCheckRepositoryExists, err)
-	}
-	slogger.Info(ctx, "DEBUG: Repository existence check completed", slogger.Fields{
-		"normalized_url": url.String(), "exists": exists,
-	})
-	if exists {
-		slogger.Info(ctx, "DEBUG: Repository already exists, returning conflict", slogger.Fields{
-			"normalized_url": url.String(),
-		})
-		return domainerrors.ErrRepositoryAlreadyExists
-	}
-	return nil
 }
 
 // createAndSaveRepository creates a repository entity and saves it to the database.

--- a/internal/application/service/repository_service_test.go
+++ b/internal/application/service/repository_service_test.go
@@ -137,7 +137,7 @@ func TestCreateRepositoryService_CreateRepository_Success(t *testing.T) {
 	}
 
 	// Mock expectations
-	mockRepo.On("Exists", mock.Anything, mock.AnythingOfType("valueobject.RepositoryURL")).Return(false, nil)
+	mockRepo.On("FindByNormalizedURL", mock.Anything, mock.AnythingOfType("valueobject.RepositoryURL")).Return(nil, nil)
 	mockRepo.On("Save", mock.Anything, mock.AnythingOfType("*entity.Repository")).Return(nil)
 	mockJobRepo.On("Save", mock.Anything, mock.AnythingOfType("*entity.IndexingJob")).Return(nil)
 	mockPublisher.On("PublishIndexingJob", mock.Anything, mock.AnythingOfType("uuid.UUID"), mock.AnythingOfType("uuid.UUID"), "https://github.com/golang/go.git").
@@ -233,7 +233,17 @@ func TestCreateRepositoryService_CreateRepository_RepositoryAlreadyExists(t *tes
 	}
 
 	// Mock expectations
-	mockRepo.On("Exists", mock.Anything, mock.AnythingOfType("valueobject.RepositoryURL")).Return(true, nil)
+	repoURL, _ := valueobject.NewRepositoryURL("https://github.com/golang/go")
+	existingRepo := entity.NewRepository(repoURL, "golang/go", nil, nil)
+	mockRepo.On("FindByNormalizedURL", mock.Anything, mock.AnythingOfType("valueobject.RepositoryURL")).Return(existingRepo, nil)
+
+	// Expect status reset
+	mockRepo.On("Update", mock.Anything, mock.AnythingOfType("*entity.Repository")).Return(nil)
+
+	// Expect job publication for the existing repository
+	mockJobRepo.On("Save", mock.Anything, mock.AnythingOfType("*entity.IndexingJob")).Return(nil)
+	mockPublisher.On("PublishIndexingJob", mock.Anything, mock.AnythingOfType("uuid.UUID"), mock.AnythingOfType("uuid.UUID"), "https://github.com/golang/go.git").
+		Return(nil)
 
 	ctx := context.Background()
 
@@ -241,13 +251,14 @@ func TestCreateRepositoryService_CreateRepository_RepositoryAlreadyExists(t *tes
 	response, err := service.CreateRepository(ctx, request)
 
 	// Assert
-	require.Error(t, err)
-	assert.Nil(t, response)
-	require.ErrorIs(t, err, domainerrors.ErrRepositoryAlreadyExists)
+	require.NoError(t, err)
+	assert.NotNil(t, response)
+	assert.Equal(t, existingRepo.ID(), response.ID)
 
 	mockRepo.AssertExpectations(t)
-	mockRepo.AssertNotCalled(t, "Save")
-	mockPublisher.AssertNotCalled(t, "PublishIndexingJob")
+	mockRepo.AssertNotCalled(t, "Save") // Should not call Save for existing repo
+	mockJobRepo.AssertExpectations(t)
+	mockPublisher.AssertExpectations(t)
 }
 
 func TestCreateRepositoryService_CreateRepository_RepositoryExistsCheckFails(t *testing.T) {
@@ -276,7 +287,7 @@ func TestCreateRepositoryService_CreateRepository_RepositoryExistsCheckFails(t *
 	}
 
 	dbError := errors.New("database connection failed")
-	mockRepo.On("Exists", mock.Anything, mock.AnythingOfType("valueobject.RepositoryURL")).Return(false, dbError)
+	mockRepo.On("FindByNormalizedURL", mock.Anything, mock.AnythingOfType("valueobject.RepositoryURL")).Return(nil, dbError)
 
 	ctx := context.Background()
 
@@ -320,7 +331,7 @@ func TestCreateRepositoryService_CreateRepository_SaveFails(t *testing.T) {
 	}
 
 	saveError := errors.New("database save failed")
-	mockRepo.On("Exists", mock.Anything, mock.AnythingOfType("valueobject.RepositoryURL")).Return(false, nil)
+	mockRepo.On("FindByNormalizedURL", mock.Anything, mock.AnythingOfType("valueobject.RepositoryURL")).Return(nil, nil)
 	mockRepo.On("Save", mock.Anything, mock.AnythingOfType("*entity.Repository")).Return(saveError)
 
 	ctx := context.Background()
@@ -364,7 +375,7 @@ func TestCreateRepositoryService_CreateRepository_PublishJobFails(t *testing.T) 
 	}
 
 	publishError := errors.New("message queue unavailable")
-	mockRepo.On("Exists", mock.Anything, mock.AnythingOfType("valueobject.RepositoryURL")).Return(false, nil)
+	mockRepo.On("FindByNormalizedURL", mock.Anything, mock.AnythingOfType("valueobject.RepositoryURL")).Return(nil, nil)
 	mockRepo.On("Save", mock.Anything, mock.AnythingOfType("*entity.Repository")).Return(nil)
 	mockJobRepo.On("Save", mock.Anything, mock.AnythingOfType("*entity.IndexingJob")).Return(nil)
 	mockPublisher.On("PublishIndexingJob", mock.Anything, mock.AnythingOfType("uuid.UUID"), mock.AnythingOfType("uuid.UUID"), "https://github.com/golang/go.git").
@@ -410,7 +421,7 @@ func TestCreateRepositoryService_CreateRepository_AutoGeneratesNameFromURL(t *te
 		// Name is empty - should be auto-generated from URL
 	}
 
-	mockRepo.On("Exists", mock.Anything, mock.AnythingOfType("valueobject.RepositoryURL")).Return(false, nil)
+	mockRepo.On("FindByNormalizedURL", mock.Anything, mock.AnythingOfType("valueobject.RepositoryURL")).Return(nil, nil)
 	mockRepo.On("Save", mock.Anything, mock.AnythingOfType("*entity.Repository")).Return(nil)
 	mockJobRepo.On("Save", mock.Anything, mock.AnythingOfType("*entity.IndexingJob")).Return(nil)
 	mockPublisher.On("PublishIndexingJob", mock.Anything, mock.AnythingOfType("uuid.UUID"), mock.AnythingOfType("uuid.UUID"), "https://github.com/golang/go.git").

--- a/internal/application/service/repository_service_url_validation_test.go
+++ b/internal/application/service/repository_service_url_validation_test.go
@@ -236,8 +236,8 @@ func TestRepositoryService_SuccessfulURLValidation(t *testing.T) {
 			service := NewCreateRepositoryService(mockRepo, mockJobRepo, mockPublisher)
 
 			// Mock repository doesn't exist
-			mockRepo.On("Exists", mock.Anything, mock.AnythingOfType("valueobject.RepositoryURL")).
-				Return(false, nil)
+			mockRepo.On("FindByNormalizedURL", mock.Anything, mock.AnythingOfType("valueobject.RepositoryURL")).
+				Return(nil, nil)
 
 			// Mock successful save
 			mockRepo.On("Save", mock.Anything, mock.AnythingOfType("*entity.Repository")).Return(nil)
@@ -375,8 +375,8 @@ func TestRepositoryService_URLValidationEdgeCases(t *testing.T) {
 
 			// Setup mocks for valid URLs BEFORE execution
 			if !tt.shouldFail {
-				mockRepo.On("Exists", mock.Anything, mock.AnythingOfType("valueobject.RepositoryURL")).
-					Return(false, nil)
+				mockRepo.On("FindByNormalizedURL", mock.Anything, mock.AnythingOfType("valueobject.RepositoryURL")).
+					Return(nil, nil)
 				mockRepo.On("Save", mock.Anything, mock.AnythingOfType("*entity.Repository")).Return(nil)
 				mockJobRepo.On("Save", mock.Anything, mock.AnythingOfType("*entity.IndexingJob")).Return(nil)
 				mockPublisher.On("PublishIndexingJob", mock.Anything, mock.AnythingOfType("uuid.UUID"), mock.AnythingOfType("uuid.UUID"), mock.AnythingOfType("string")).

--- a/internal/application/service/service_integration_test.go
+++ b/internal/application/service/service_integration_test.go
@@ -111,8 +111,8 @@ func TestRepositoryServiceBehaviorSpecification(t *testing.T) {
 				// Name is empty - should be generated
 			}
 
-			mockRepo.On("Exists", context.Background(), mock.AnythingOfType("valueobject.RepositoryURL")).
-				Return(false, nil)
+			mockRepo.On("FindByNormalizedURL", context.Background(), mock.AnythingOfType("valueobject.RepositoryURL")).
+				Return(nil, nil)
 			mockRepo.On("Save", context.Background(), mock.AnythingOfType("*entity.Repository")).Return(nil)
 			mockJobRepo.On("Save", context.Background(), mock.AnythingOfType("*entity.IndexingJob")).Return(nil)
 			mockPublisher.On("PublishIndexingJob", context.Background(), mock.AnythingOfType("uuid.UUID"), mock.AnythingOfType("uuid.UUID"), "https://github.com/golang/go.git").
@@ -136,8 +136,8 @@ func TestRepositoryServiceBehaviorSpecification(t *testing.T) {
 				Name: "golang/go",
 			}
 
-			mockRepo.On("Exists", context.Background(), mock.AnythingOfType("valueobject.RepositoryURL")).
-				Return(false, nil)
+			mockRepo.On("FindByNormalizedURL", context.Background(), mock.AnythingOfType("valueobject.RepositoryURL")).
+				Return(nil, nil)
 			mockRepo.On("Save", context.Background(), mock.AnythingOfType("*entity.Repository")).Return(nil)
 			mockJobRepo.On("Save", context.Background(), mock.AnythingOfType("*entity.IndexingJob")).Return(nil)
 			mockPublisher.On("PublishIndexingJob", context.Background(), mock.AnythingOfType("uuid.UUID"), mock.AnythingOfType("uuid.UUID"), "https://github.com/golang/go.git").

--- a/internal/application/worker/job_processor.go
+++ b/internal/application/worker/job_processor.go
@@ -1982,8 +1982,9 @@ func (p *DefaultJobProcessor) processBatchEmbeddings(
 	// Convert UUID to string for backward compatibility with existing code
 	jobID := indexingJobID.String()
 
-	// PRE-FLIGHT: Count tokens before embedding generation (non-blocking)
-	p.countTokensForChunks(ctx, repositoryID, chunks)
+	// Fire token counting in a separate goroutine so it doesn't block embedding generation.
+	// Uses a detached context so job cancellation doesn't abort an in-progress count.
+	go p.countTokensForChunks(context.WithoutCancel(ctx), repositoryID, chunks)
 
 	// Check context before starting batch processing
 	if err := ctx.Err(); err != nil {
@@ -2248,8 +2249,9 @@ func (p *DefaultJobProcessor) processSequentialEmbeddings(
 	// Convert UUID to string for backward compatibility
 	jobID := indexingJobID.String()
 
-	// PRE-FLIGHT: Count tokens before embedding generation (non-blocking)
-	p.countTokensForChunks(ctx, repositoryID, chunks)
+	// Fire token counting in a separate goroutine so it doesn't block embedding generation.
+	// Uses a detached context so job cancellation doesn't abort an in-progress count.
+	go p.countTokensForChunks(context.WithoutCancel(ctx), repositoryID, chunks)
 
 	if p.batchConfig.UseTestEmbeddings {
 		// Test mode: use test embeddings

--- a/internal/client/commands/repos.go
+++ b/internal/client/commands/repos.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"codechunking/internal/application/dto"
 	"codechunking/internal/client"
-	"codechunking/internal/domain/valueobject"
 	"context"
 	"io"
 
@@ -300,7 +299,7 @@ func NewReposDeleteCmd() *cobra.Command {
 
 			return client.WriteSuccess(cmd.OutOrStdout(), map[string]string{
 				"id":     id.String(),
-				"status": string(valueobject.RepositoryStatusArchived),
+				"status": "archived",
 			})
 		},
 	}

--- a/internal/domain/entity/repository.go
+++ b/internal/domain/entity/repository.go
@@ -279,6 +279,11 @@ func (r *Repository) UpdateStatus(newStatus valueobject.RepositoryStatus) error 
 	return nil
 }
 
+// ResetForReindexing resets the repository status to pending to allow a full re-index.
+func (r *Repository) ResetForReindexing() error {
+	return r.UpdateStatus(valueobject.RepositoryStatusPending)
+}
+
 // MarkIndexingCompleted marks the repository as successfully indexed.
 func (r *Repository) MarkIndexingCompleted(commitHash string, totalFiles, totalChunks int) error {
 	if err := r.UpdateStatus(valueobject.RepositoryStatusCompleted); err != nil {

--- a/internal/domain/valueobject/repository_status.go
+++ b/internal/domain/valueobject/repository_status.go
@@ -53,18 +53,22 @@ func (s RepositoryStatus) IsTerminal() bool {
 func (s RepositoryStatus) CanTransitionTo(target RepositoryStatus) bool {
 	transitions := map[RepositoryStatus][]RepositoryStatus{
 		RepositoryStatusPending: {
+			RepositoryStatusPending, // Allow re-triggering while pending
 			RepositoryStatusCloning,
 			RepositoryStatusFailed,
 		},
 		RepositoryStatusCloning: {
+			RepositoryStatusPending, // Allow re-triggering while cloning
 			RepositoryStatusProcessing,
 			RepositoryStatusFailed,
 		},
 		RepositoryStatusProcessing: {
+			RepositoryStatusPending, // Allow re-triggering while processing
 			RepositoryStatusCompleted,
 			RepositoryStatusFailed,
 		},
 		RepositoryStatusCompleted: {
+			RepositoryStatusPending,    // For re-indexing
 			RepositoryStatusProcessing, // For re-indexing
 			RepositoryStatusCompleted,  // Allow idempotent completion (re-indexing same commit)
 			RepositoryStatusArchived,

--- a/internal/port/outbound/job_processor.go
+++ b/internal/port/outbound/job_processor.go
@@ -417,6 +417,10 @@ type CodeParsingConfig struct {
 	FileFilters      []string
 	IncludeTests     bool
 	ExcludeVendor    bool
+	// ParseConcurrency controls how many files are parsed in parallel inside
+	// ParseDirectory. A value of 0 means "use runtime.GOMAXPROCS(0)". A value
+	// of 1 disables parallelism entirely. Values >1 bound the worker pool.
+	ParseConcurrency int
 }
 
 // ====================== CACHING INTERFACES ======================


### PR DESCRIPTION
…, zoekt in Docker

- Parallelize ParseDirectory with bounded errgroup worker pool
- Re-trigger indexing instead of erroring on already-exists shards
- Bump worker and zoekt concurrent indexing to 12
- Move token counting to detached goroutine so embedding isn't blocked
- Bundle zoekt-git-index binary into Docker image for in-container indexing
- Switch token counting mode to sample (10%) for dev
- Fix zoekt volume to /tmp/zoekt-index with correct user