### PR TITLE
feat: improve GitLab sync and connector management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,6 +236,10 @@ slogger.Error(ctx, "Database error", slogger.Fields{"error": err})
 
 ## Development Best Practices
 
+### Database Migrations
+- **`CREATE INDEX CONCURRENTLY`** must always live in its own dedicated migration file — golang-migrate runs migrations inside a transaction by default, and `CONCURRENTLY` cannot execute inside a transaction (it will error). Only use `CONCURRENTLY` when adding indexes to existing tables with live data; for new tables created in the same migration, non-concurrent indexes are fine (empty table = no lock contention).
+- Never use `ALTER SYSTEM` in migrations — it writes to `postgresql.conf` and affects all databases on the instance. It belongs in ops config, not schema migrations.
+
 ### Code Organization
 - Keep files under 500 lines (preferred), max 1000 lines for readability and parsability
 - Follow hexagonal architecture patterns (domain, application, port, adapter layers)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 # Variables
 BINARY_NAME=codechunking
-DOCKER_COMPOSE=docker compose
+DOCKER_COMPOSE ?= docker compose
 GO_CMD=go
 MIGRATE_CMD=migrate
 
@@ -144,11 +144,11 @@ install-client: build-client
 
 ## migrate-up: Apply all database migrations
 migrate-up:
-	$(GO_CMD) run main.go migrate up --config configs/config.dev.yaml
+	CGO_ENABLED=1 CGO_CXXFLAGS="-std=c++11" $(GO_CMD) run main.go migrate up --config configs/config.dev.yaml
 
 ## migrate-down: Rollback all database migrations
 migrate-down:
-	$(GO_CMD) run main.go migrate down
+	CGO_ENABLED=1 CGO_CXXFLAGS="-std=c++11" $(GO_CMD) run main.go migrate down --config configs/config.dev.yaml
 
 ## migrate-create: Create a new migration (usage: make migrate-create name=migration_name)
 migrate-create:

--- a/cmd/api.go
+++ b/cmd/api.go
@@ -14,6 +14,7 @@ import (
 	"codechunking/internal/adapter/outbound/repository"
 	"codechunking/internal/adapter/outbound/zoekt"
 	"codechunking/internal/application/common/slogger"
+	"codechunking/internal/application/dto"
 	"codechunking/internal/application/registry"
 	appservice "codechunking/internal/application/service"
 	"codechunking/internal/config"
@@ -40,6 +41,13 @@ const (
 	// Server timeout constants.
 	serverStartTimeoutSeconds    = 10
 	serverShutdownTimeoutSeconds = 30
+
+	// syncConnectorConcurrency is the maximum number of connector syncs that run in parallel
+	// at startup to avoid overloading the database, GitLab API, and NATS.
+	syncConnectorConcurrency = 5
+
+	// syncConnectorTimeout is the per-connector sync timeout.
+	syncConnectorTimeout = 10 * time.Minute
 )
 
 // ServiceFactory creates and manages service instances with memoized database connection pooling.
@@ -257,6 +265,71 @@ func (sf *ServiceFactory) ReconcileConnectors(ctx context.Context) {
 	if err := reconciler.Reconcile(ctx, sf.config.Connectors); err != nil {
 		slogger.Error(ctx, "Connector reconciliation failed", slogger.Fields{"error": err.Error()})
 	}
+}
+
+// SyncAllConnectors triggers a background sync for every active connector using
+// paginated listing to avoid fetching unlimited rows in a single query.
+// Syncs run through a bounded worker pool to avoid overloading downstream services.
+// The caller should pass a fully-initialized ConnectorService (e.g., the same one used
+// by the server) to avoid creating a duplicate NATS connection at startup.
+// Non-fatal: errors per connector are logged and skipped.
+// The returned channel closes when all in-flight syncs have drained; callers may
+// select on it during graceful shutdown. Cancelling ctx stops fetching new pages
+// but lets already-dispatched syncs complete.
+func (sf *ServiceFactory) SyncAllConnectors(ctx context.Context, connectorSvc inbound.ConnectorService) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done) // runs LAST (registered first, LIFO)
+		sem := make(chan struct{}, syncConnectorConcurrency)
+		var wg sync.WaitGroup
+		defer wg.Wait() // runs FIRST (registered last, LIFO) — blocks until all workers done
+
+		offset := 0
+		for {
+			page, err := connectorSvc.ListConnectors(ctx, dto.ConnectorListQuery{
+				Limit:  dto.MaxLimitValue,
+				Offset: offset,
+				Status: "active",
+			})
+			if err != nil {
+				slogger.Error(ctx, "SyncAllConnectors: list page failed",
+					slogger.Fields{"offset": offset, "error": err.Error()})
+				break
+			}
+			slogger.Info(ctx, "SyncAllConnectors: dispatching page", slogger.Fields{
+				"offset": offset,
+				"count":  len(page.Connectors),
+			})
+			for _, c := range page.Connectors {
+				id := c.ID
+				sem <- struct{}{}
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					defer func() { <-sem }()
+					syncCtx, cancel := context.WithTimeout(ctx, syncConnectorTimeout)
+					defer cancel()
+					resp, err := connectorSvc.SyncConnector(syncCtx, id)
+					if err != nil {
+						slogger.Error(syncCtx, "SyncAllConnectors: sync failed", slogger.Fields{
+							"connector_id": id,
+							"error":        err.Error(),
+						})
+						return
+					}
+					slogger.Info(syncCtx, "SyncAllConnectors: sync completed", slogger.Fields{
+						"connector_id":       id,
+						"repositories_found": resp.RepositoriesFound,
+					})
+				}()
+			}
+			if !page.Pagination.HasMore || ctx.Err() != nil {
+				break
+			}
+			offset += dto.MaxLimitValue
+		}
+	}()
+	return done
 }
 
 // CreateRepositoryService creates a repository service instance with fail-fast error handling.
@@ -602,20 +675,24 @@ Configuration is loaded from config files and environment variables.`,
 }
 
 func runAPIServer(_ *cobra.Command, _ []string) {
-	// Load configuration
 	cfg := GetConfig()
-
-	// Create service factory
 	serviceFactory := NewServiceFactory(cfg)
 
-	serviceFactory.ReconcileConnectors(context.Background())
+	rootCtx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
 
-	// Create server using the factory
+	serviceFactory.ReconcileConnectors(rootCtx)
+
+	// Create server using the factory - this also initializes the NATS connection.
 	server, err := serviceFactory.CreateServer()
 	if err != nil {
 		slogger.ErrorNoCtx("Failed to create server", slogger.Field("error", err))
-		os.Exit(1)
+		os.Exit(1) //nolint:gocritic // intentional exit without defer in error path
 	}
+
+	// Trigger background sync after the server's NATS connection is established, reusing
+	// the same fully-initialized connector service rather than creating a separate one.
+	syncDone := serviceFactory.SyncAllConnectors(rootCtx, serviceFactory.CreateConnectorService())
 
 	// Start server with timeout
 	startCtx, startCancel := context.WithTimeout(context.Background(), serverStartTimeoutSeconds*time.Second)
@@ -623,37 +700,38 @@ func runAPIServer(_ *cobra.Command, _ []string) {
 
 	if startErr := server.Start(startCtx); startErr != nil {
 		slogger.ErrorNoCtx("Failed to start server", slogger.Field("error", startErr.Error()))
-		os.Exit(1) //nolint:gocritic // intentional exit without defer in error path
+		os.Exit(1)
 	}
 
 	slogger.InfoNoCtx("API server started successfully", slogger.Field("address", server.Address()))
 	slogger.InfoNoCtx("Server configuration", slogger.Fields2("host", server.Host(), "port", server.Port()))
 	slogger.InfoNoCtx("Middleware enabled", slogger.Field("count", server.MiddlewareCount()))
 
-	// Create a graceful shutdown handler
-	gracefulShutdown(server)
+	gracefulShutdown(server, rootCtx, syncDone)
 }
 
-// gracefulShutdown handles graceful server shutdown with proper signal handling.
-func gracefulShutdown(server *api.Server) {
-	// Create a channel to receive OS signals
-	sigChan := make(chan os.Signal, 1)
+// gracefulShutdown handles graceful server shutdown, waiting for rootCtx cancellation
+// (i.e. SIGINT/SIGTERM delivered via signal.NotifyContext in the caller). After the
+// HTTP server shuts down it waits for in-flight connector syncs to drain or for the
+// shutdown timeout to expire, whichever comes first.
+func gracefulShutdown(server *api.Server, rootCtx context.Context, syncDone <-chan struct{}) {
+	<-rootCtx.Done()
+	slogger.InfoNoCtx("Received shutdown signal. Initiating graceful shutdown", nil)
 
-	// Register the channel to receive specific signals
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-
-	// Wait for a signal
-	sig := <-sigChan
-	slogger.InfoNoCtx("Received signal. Initiating graceful shutdown", slogger.Field("signal", sig))
-
-	// Create a context with timeout for shutdown
+	// Derive shutdown timeout from a fresh background context — rootCtx is already
+	// cancelled at this point so we must not inherit from it.
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), serverShutdownTimeoutSeconds*time.Second)
 	defer shutdownCancel()
 
-	// Attempt graceful shutdown
 	if err := server.Shutdown(shutdownCtx); err != nil {
 		slogger.ErrorNoCtx("Error during server shutdown", slogger.Field("error", err))
 		os.Exit(1) //nolint:gocritic // intentional exit without defer in error path
+	}
+
+	// Wait for in-flight connector syncs to drain (or timeout).
+	select {
+	case <-syncDone:
+	case <-shutdownCtx.Done():
 	}
 
 	slogger.InfoNoCtx("API server shut down gracefully", nil)

--- a/cmd/sync_all_connectors_test.go
+++ b/cmd/sync_all_connectors_test.go
@@ -1,0 +1,322 @@
+package cmd
+
+import (
+	"codechunking/internal/application/dto"
+	"codechunking/internal/config"
+	"codechunking/internal/port/inbound"
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// mockConnectorSvc is a local test double for inbound.ConnectorService.
+type mockConnectorSvc struct {
+	mu sync.Mutex
+
+	ListConnectorsFunc func(ctx context.Context, query dto.ConnectorListQuery) (*dto.ConnectorListResponse, error)
+	SyncConnectorFunc  func(ctx context.Context, id uuid.UUID) (*dto.SyncConnectorResponse, error)
+
+	listCalls []dto.ConnectorListQuery
+	syncCalls []uuid.UUID
+}
+
+func (m *mockConnectorSvc) GetConnector(_ context.Context, _ uuid.UUID) (*dto.ConnectorResponse, error) {
+	return nil, errors.New("not implemented in mock")
+}
+
+func (m *mockConnectorSvc) ListConnectors(ctx context.Context, query dto.ConnectorListQuery) (*dto.ConnectorListResponse, error) {
+	m.mu.Lock()
+	m.listCalls = append(m.listCalls, query)
+	m.mu.Unlock()
+	if m.ListConnectorsFunc != nil {
+		return m.ListConnectorsFunc(ctx, query)
+	}
+	return &dto.ConnectorListResponse{}, nil
+}
+
+func (m *mockConnectorSvc) SyncConnector(ctx context.Context, id uuid.UUID) (*dto.SyncConnectorResponse, error) {
+	m.mu.Lock()
+	m.syncCalls = append(m.syncCalls, id)
+	m.mu.Unlock()
+	if m.SyncConnectorFunc != nil {
+		return m.SyncConnectorFunc(ctx, id)
+	}
+	return &dto.SyncConnectorResponse{}, nil
+}
+
+func (m *mockConnectorSvc) listCallsCopy() []dto.ConnectorListQuery {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]dto.ConnectorListQuery, len(m.listCalls))
+	copy(out, m.listCalls)
+	return out
+}
+
+func (m *mockConnectorSvc) syncCallsCopy() []uuid.UUID {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]uuid.UUID, len(m.syncCalls))
+	copy(out, m.syncCalls)
+	return out
+}
+
+var _ inbound.ConnectorService = (*mockConnectorSvc)(nil)
+
+// awaitDone blocks until the done channel closes or 5 s elapses.
+func awaitDone(t *testing.T, done <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("SyncAllConnectors done channel did not close within 5 s")
+	}
+}
+
+// newSF builds a minimal ServiceFactory suitable for unit tests (no real DB/NATS).
+func newSF() *ServiceFactory {
+	return NewServiceFactory(&config.Config{})
+}
+
+// makeConnectors returns a slice of ConnectorResponse stubs with distinct UUIDs.
+func makeConnectors(n int) []dto.ConnectorResponse {
+	out := make([]dto.ConnectorResponse, n)
+	for i := range n {
+		out[i] = dto.ConnectorResponse{ID: uuid.New()}
+	}
+	return out
+}
+
+// pagedResponse builds a ConnectorListResponse for a given page of connectors.
+func pagedResponse(connectors []dto.ConnectorResponse, hasMore bool) *dto.ConnectorListResponse {
+	return &dto.ConnectorListResponse{
+		Connectors: connectors,
+		Pagination: dto.PaginationResponse{HasMore: hasMore},
+	}
+}
+
+func TestSyncAllConnectors_PaginatesAcrossThreePages(t *testing.T) {
+	t.Parallel()
+
+	page0 := makeConnectors(100) // offset 0, HasMore true
+	page1 := makeConnectors(100) // offset 100, HasMore true
+	page2 := makeConnectors(50)  // offset 200, HasMore false
+
+	mock := &mockConnectorSvc{
+		ListConnectorsFunc: func(_ context.Context, q dto.ConnectorListQuery) (*dto.ConnectorListResponse, error) {
+			switch q.Offset {
+			case 0:
+				return pagedResponse(page0, true), nil
+			case 100:
+				return pagedResponse(page1, true), nil
+			case 200:
+				return pagedResponse(page2, false), nil
+			default:
+				return pagedResponse(nil, false), nil
+			}
+		},
+		SyncConnectorFunc: func(_ context.Context, _ uuid.UUID) (*dto.SyncConnectorResponse, error) {
+			return &dto.SyncConnectorResponse{}, nil
+		},
+	}
+
+	done := newSF().SyncAllConnectors(context.Background(), mock)
+	awaitDone(t, done)
+
+	listCalls := mock.listCallsCopy()
+	if len(listCalls) != 3 {
+		t.Fatalf("expected 3 ListConnectors calls, got %d", len(listCalls))
+	}
+	if listCalls[0].Offset != 0 || listCalls[0].Limit != dto.MaxLimitValue {
+		t.Errorf("page 0 query mismatch: %+v", listCalls[0])
+	}
+	if listCalls[1].Offset != 100 || listCalls[1].Limit != dto.MaxLimitValue {
+		t.Errorf("page 1 query mismatch: %+v", listCalls[1])
+	}
+	if listCalls[2].Offset != 200 || listCalls[2].Limit != dto.MaxLimitValue {
+		t.Errorf("page 2 query mismatch: %+v", listCalls[2])
+	}
+
+	syncCalls := mock.syncCallsCopy()
+	if len(syncCalls) != 250 {
+		t.Errorf("expected 250 SyncConnector calls, got %d", len(syncCalls))
+	}
+}
+
+func TestSyncAllConnectors_EmptyFirstPageIsCleanExit(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockConnectorSvc{
+		ListConnectorsFunc: func(_ context.Context, _ dto.ConnectorListQuery) (*dto.ConnectorListResponse, error) {
+			return pagedResponse(nil, false), nil
+		},
+	}
+
+	done := newSF().SyncAllConnectors(context.Background(), mock)
+	awaitDone(t, done)
+
+	if calls := mock.syncCallsCopy(); len(calls) != 0 {
+		t.Errorf("expected 0 SyncConnector calls, got %d", len(calls))
+	}
+}
+
+func TestSyncAllConnectors_RespectsShutdownContextMidIteration(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var listCallCount int32
+	mock := &mockConnectorSvc{
+		ListConnectorsFunc: func(_ context.Context, q dto.ConnectorListQuery) (*dto.ConnectorListResponse, error) {
+			n := atomic.AddInt32(&listCallCount, 1)
+			if n == 1 {
+				// First page returns data + HasMore; cancel ctx before second page.
+				cancel()
+				return pagedResponse(makeConnectors(10), true), nil
+			}
+			return pagedResponse(makeConnectors(10), false), nil
+		},
+		SyncConnectorFunc: func(_ context.Context, _ uuid.UUID) (*dto.SyncConnectorResponse, error) {
+			return &dto.SyncConnectorResponse{}, nil
+		},
+	}
+
+	done := newSF().SyncAllConnectors(ctx, mock)
+	awaitDone(t, done)
+
+	// After ctx cancel, no further ListConnectors calls must be issued.
+	if n := atomic.LoadInt32(&listCallCount); n > 1 {
+		t.Errorf("expected at most 1 ListConnectors call after cancel, got %d", n)
+	}
+}
+
+func TestSyncAllConnectors_BoundedConcurrency(t *testing.T) {
+	t.Parallel()
+
+	const connectorCount = 20
+
+	// allBlocked is closed once syncConnectorConcurrency workers are simultaneously
+	// blocked inside SyncConnector, proving the semaphore is saturated.
+	allBlocked := make(chan struct{})
+	var blockedOnce sync.Once
+	release := make(chan struct{})
+
+	var inflight int32
+	var peakInflight int32
+
+	mock := &mockConnectorSvc{
+		ListConnectorsFunc: func(_ context.Context, _ dto.ConnectorListQuery) (*dto.ConnectorListResponse, error) {
+			return pagedResponse(makeConnectors(connectorCount), false), nil
+		},
+		SyncConnectorFunc: func(_ context.Context, _ uuid.UUID) (*dto.SyncConnectorResponse, error) {
+			cur := atomic.AddInt32(&inflight, 1)
+			for {
+				peak := atomic.LoadInt32(&peakInflight)
+				if cur <= peak || atomic.CompareAndSwapInt32(&peakInflight, peak, cur) {
+					break
+				}
+			}
+			// Signal once the semaphore is fully saturated so the test can
+			// unblock workers without relying on a fixed sleep duration.
+			if atomic.LoadInt32(&inflight) >= int32(syncConnectorConcurrency) {
+				blockedOnce.Do(func() { close(allBlocked) })
+			}
+			<-release
+			atomic.AddInt32(&inflight, -1)
+			return &dto.SyncConnectorResponse{}, nil
+		},
+	}
+
+	done := newSF().SyncAllConnectors(context.Background(), mock)
+
+	// Wait until the semaphore is fully saturated, then release all workers.
+	select {
+	case <-allBlocked:
+	case <-time.After(5 * time.Second):
+		t.Fatal("workers did not saturate the semaphore within 5 s")
+	}
+	close(release)
+
+	awaitDone(t, done)
+
+	if peak := atomic.LoadInt32(&peakInflight); peak > syncConnectorConcurrency {
+		t.Errorf("peak concurrency %d exceeded syncConnectorConcurrency=%d", peak, syncConnectorConcurrency)
+	}
+}
+
+func TestSyncAllConnectors_PerConnectorErrorLoggedSiblingsComplete(t *testing.T) {
+	t.Parallel()
+
+	ids := makeConnectors(5)
+	failID := ids[2].ID
+
+	mock := &mockConnectorSvc{
+		ListConnectorsFunc: func(_ context.Context, _ dto.ConnectorListQuery) (*dto.ConnectorListResponse, error) {
+			return pagedResponse(ids, false), nil
+		},
+		SyncConnectorFunc: func(_ context.Context, id uuid.UUID) (*dto.SyncConnectorResponse, error) {
+			if id == failID {
+				return nil, errors.New("simulated sync failure")
+			}
+			return &dto.SyncConnectorResponse{}, nil
+		},
+	}
+
+	done := newSF().SyncAllConnectors(context.Background(), mock)
+	awaitDone(t, done)
+
+	if calls := mock.syncCallsCopy(); len(calls) != 5 {
+		t.Errorf("expected 5 SyncConnector calls (including the failing one), got %d", len(calls))
+	}
+}
+
+func TestSyncAllConnectors_ListErrorOnFirstPageAbortsCleanly(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockConnectorSvc{
+		ListConnectorsFunc: func(_ context.Context, _ dto.ConnectorListQuery) (*dto.ConnectorListResponse, error) {
+			return nil, errors.New("db unavailable")
+		},
+	}
+
+	done := newSF().SyncAllConnectors(context.Background(), mock)
+	awaitDone(t, done)
+
+	if calls := mock.syncCallsCopy(); len(calls) != 0 {
+		t.Errorf("expected 0 SyncConnector calls after list error, got %d", len(calls))
+	}
+}
+
+func TestSyncAllConnectors_ListErrorOnLaterPageAbortsCleanly(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockConnectorSvc{
+		ListConnectorsFunc: func(_ context.Context, q dto.ConnectorListQuery) (*dto.ConnectorListResponse, error) {
+			if q.Offset == 0 {
+				return pagedResponse(makeConnectors(dto.MaxLimitValue), true), nil
+			}
+			return nil, errors.New("db intermittent error")
+		},
+		SyncConnectorFunc: func(_ context.Context, _ uuid.UUID) (*dto.SyncConnectorResponse, error) {
+			return &dto.SyncConnectorResponse{}, nil
+		},
+	}
+
+	done := newSF().SyncAllConnectors(context.Background(), mock)
+	awaitDone(t, done)
+
+	// Page 0 connectors dispatched; page 1 never fetched due to error.
+	listCalls := mock.listCallsCopy()
+	if len(listCalls) != 2 {
+		t.Errorf("expected exactly 2 ListConnectors calls, got %d", len(listCalls))
+	}
+	// Syncs for page 0 complete; none from the errored page.
+	syncCalls := mock.syncCallsCopy()
+	if len(syncCalls) != dto.MaxLimitValue {
+		t.Errorf("expected %d SyncConnector calls (page 0 only), got %d", dto.MaxLimitValue, len(syncCalls))
+	}
+}

--- a/configs/config.dev.yaml
+++ b/configs/config.dev.yaml
@@ -6,7 +6,7 @@ zoekt:
     port: 6070
   indexing:
     git_index_path: zoekt-git-index
-    index_dir: /home/anthony/tmp/zoekt-index
+    index_dir: /data/index
     timeout: 10m
   concurrent_indexing:
     enabled: true
@@ -31,6 +31,7 @@ log:
 #     auth_token: "${GITLAB_TOKEN}"
 #     groups:
 #       - my-group
+#       - my-group/subgroup
 # Gemini API key should be set via environment variable:
 # export CODECHUNK_GEMINI_API_KEY=your-api-key
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,10 +55,11 @@ services:
       - tools
 
   zoekt-webserver:
-    image: ghcr.io/sourcegraph/zoekt:latest
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.zoekt
     container_name: codechunking-zoekt-webserver
-    user: "1000:1000"
-    command: ["zoekt-webserver", "-index", "/data/index", "-pprof", "-rpc" ]  # HTTP on 6070, gRPC on 6071
+    command: ["-index", "/data/index", "-pprof", "-rpc"]  # HTTP on 6070, gRPC on 6071
     ports:
       - name: zoekt-http
         target: 6070
@@ -69,7 +70,7 @@ services:
         published: "6071"
         protocol: tcp
     volumes:
-      - ${HOME:-/tmp}/tmp/zoekt-index:/data/index
+      - zoekt_data:/data/index
     healthcheck:
       test: ["CMD-SHELL", "wget -q --spider http://localhost:6070/healthz || exit 1"]
       interval: 10s
@@ -91,7 +92,8 @@ services:
       - CODECHUNK_DATABASE_USER=dev
       - CODECHUNK_DATABASE_PASSWORD=dev
       - CODECHUNK_NATS_URL=nats://nats:4222
-      # Gemini API key for search functionality
+      - CODECHUNK_GEMINI_API_KEY=${CODECHUNK_GEMINI_API_KEY}
+      - GITLAB_TOKEN=${GITLAB_TOKEN}
     ports:
       - "8080:8080"
     command: ["api", "--config", "configs/config.dev.yaml"]
@@ -132,7 +134,8 @@ services:
       - CODECHUNK_DATABASE_USER=dev
       - CODECHUNK_DATABASE_PASSWORD=dev
       - CODECHUNK_NATS_URL=nats://nats:4222
-      # - CODECHUNK_GEMINI_API_KEY=your-api-key
+      - CODECHUNK_GEMINI_API_KEY=${CODECHUNK_GEMINI_API_KEY}
+      - GITLAB_TOKEN=${GITLAB_TOKEN}
     command: ["worker", "--config", "configs/config.dev.yaml"]
     restart: unless-stopped
     volumes:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,10 @@
-# Zoekt stage - extract indexing binary
-FROM ghcr.io/sourcegraph/zoekt:latest AS zoekt
+# Build zoekt binaries from source for multi-arch (arm64/amd64) compatibility
+FROM golang:1.25-bookworm AS zoekt-builder
+ARG ZOEKT_VERSION=v0.0.0-20260410121455-f469edd14f92
+RUN go install github.com/sourcegraph/zoekt/cmd/zoekt-git-index@${ZOEKT_VERSION}
 
 # Build stage - use Debian-based image to avoid musl libc issues
-FROM golang:1.24-bookworm AS builder
+FROM golang:1.25-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -12,21 +14,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Set working directory
 WORKDIR /app
 
-# Copy go mod files
+# Copy dependency manifests first for better layer caching
 COPY go.mod go.sum ./
-
-# Download dependencies
-RUN go mod download
-
-# Copy source code
-COPY . .
 
 # Build arguments for version information
 ARG VERSION=dev
 ARG COMMIT=unknown
 ARG BUILD_TIME=unknown
 
-# Build the binary with version ldflags
+# Download dependencies (cached unless go.mod/go.sum change)
+RUN go mod download
+
+# Copy remaining source code
+COPY . .
+
+# Build the binary
 RUN CGO_ENABLED=1 GOOS=linux go build \
     -ldflags="-s -w \
     -X codechunking/cmd.Version=${VERSION} \
@@ -52,8 +54,8 @@ WORKDIR /app
 # Copy binary from builder
 COPY --from=builder /app/codechunking /app/codechunking
 
-# Copy zoekt indexing binary
-COPY --from=zoekt /usr/local/bin/zoekt-git-index /usr/local/bin/zoekt-git-index
+# Copy zoekt indexing binary (built from source for arm64 compatibility)
+COPY --from=zoekt-builder /go/bin/zoekt-git-index /usr/local/bin/zoekt-git-index
 
 # Copy configuration files
 COPY --from=builder /app/configs /app/configs

--- a/docker/Dockerfile.zoekt
+++ b/docker/Dockerfile.zoekt
@@ -1,0 +1,35 @@
+# Build zoekt from source for multi-arch compatibility (including arm64)
+FROM golang:1.25-bookworm AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Pin to the same version used in go.mod
+ARG ZOEKT_VERSION=v0.0.0-20260410121455-f469edd14f92
+RUN go install github.com/sourcegraph/zoekt/cmd/zoekt-webserver@${ZOEKT_VERSION} && \
+    go install github.com/sourcegraph/zoekt/cmd/zoekt-git-index@${ZOEKT_VERSION}
+
+# Runtime image
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates git wget && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN groupadd -g 1000 zoekt && \
+    useradd -u 1000 -g zoekt -m -s /bin/bash zoekt
+
+COPY --from=builder /go/bin/zoekt-webserver /usr/local/bin/zoekt-webserver
+COPY --from=builder /go/bin/zoekt-git-index /usr/local/bin/zoekt-git-index
+
+RUN mkdir -p /data/index && chown -R zoekt:zoekt /data
+
+USER zoekt
+
+EXPOSE 6070 6071
+
+ENTRYPOINT ["zoekt-webserver"]
+CMD ["-index", "/data/index", "-pprof", "-rpc"]

--- a/internal/adapter/outbound/gitclient/authenticated_git_client.go
+++ b/internal/adapter/outbound/gitclient/authenticated_git_client.go
@@ -97,12 +97,32 @@ func NewAuthenticatedGitClient() outbound.AuthenticatedGitClient {
 
 // Basic GitClient methods (minimal implementation)
 
-// Clone performs a basic git clone.
+// Clone performs a git clone, delegating to the appropriate authenticated variant
+// when credentials are available in the environment. Falls through to a plain
+// unauthenticated clone only when no credentials are found.
 func (c *AuthenticatedGitClientImpl) Clone(ctx context.Context, repoURL, targetPath string) error {
-	// Execute real git clone command
-	cmd := exec.CommandContext(ctx, "git", "clone", repoURL, targetPath)
-	output, err := cmd.CombinedOutput()
+	authConfig, err := c.LoadCredentialsFromEnvironment(ctx, repoURL)
 	if err != nil {
+		var gitErr *outbound.GitOperationError
+		if !errors.As(err, &gitErr) || gitErr.Type != "env_credentials_not_found" {
+			return err
+		}
+		// env_credentials_not_found sentinel — fall through to plain clone below.
+	} else {
+		opts := valueobject.CloneOptions{}
+		switch cfg := authConfig.(type) {
+		case *outbound.TokenAuthConfig:
+			_, err := c.CloneWithTokenAuth(ctx, repoURL, targetPath, opts, cfg)
+			return err
+		case *outbound.SSHAuthConfig:
+			_, err := c.CloneWithSSHAuth(ctx, repoURL, targetPath, opts, cfg)
+			return err
+		}
+	}
+
+	cmd := exec.CommandContext(ctx, "git", "clone", repoURL, targetPath)
+	output, cmdErr := cmd.CombinedOutput()
+	if cmdErr != nil {
 		return &outbound.GitOperationError{
 			Type:    "clone_failed",
 			Message: fmt.Sprintf("git clone failed: %s", string(output)),
@@ -473,9 +493,9 @@ func (c *AuthenticatedGitClientImpl) DiscoverSSHKeys(
 
 	for _, key := range keyPriority {
 		keyPath := filepath.Join(sshDir, key.name)
-		if _, err := os.Stat(keyPath); err == nil {
+		if _, err := os.Stat(keyPath); err == nil { //nolint:gosec // keyPath is constructed from a fixed list of known key names joined with a validated ssh dir
 			// Check if this is a private key (not .pub file)
-			content, err := os.ReadFile(keyPath)
+			content, err := os.ReadFile(keyPath) //nolint:gosec // keyPath is constructed from a fixed list of known key names joined with a validated ssh dir
 			if err != nil {
 				continue
 			}

--- a/internal/adapter/outbound/gitclient/clone_auth_dispatch_test.go
+++ b/internal/adapter/outbound/gitclient/clone_auth_dispatch_test.go
@@ -1,0 +1,413 @@
+package gitclient
+
+// TestCloneAuthDispatch verifies the dispatch contract of Clone() on
+// AuthenticatedGitClientImpl.
+//
+// Contract under test:
+//
+//	Clone(ctx, repoURL, targetPath) must:
+//	  1. Call LoadCredentialsFromEnvironment to detect credentials
+//	  2. TokenAuthConfig found  → delegate to CloneWithTokenAuth (stub: returns nil)
+//	  3. SSHAuthConfig found    → delegate to CloneWithSSHAuth   (stub: returns nil)
+//	  4. env_credentials_not_found → plain unauthenticated clone (returns clone_failed for bad URLs)
+//	  5. Any other error from LoadCredentialsFromEnvironment → propagate that error unchanged
+//
+// Detection strategy: CloneWithTokenAuth and CloneWithSSHAuth are stub
+// implementations that return mock success without touching the network.
+// A plain clone against a non-existent URL always produces a clone_failed error,
+// so tests distinguish the dispatch path by whether Clone() returns nil or an error.
+//
+// t.Setenv and t.Parallel are mutually exclusive — these tests run sequentially.
+
+import (
+	"codechunking/internal/port/outbound"
+	"context"
+	"errors"
+	"os"
+	"testing"
+)
+
+// ----------------------------------------------------------------------------
+// helpers
+// ----------------------------------------------------------------------------
+
+// newDispatchTestClient returns the real AuthenticatedGitClientImpl so that we
+// test through the actual struct rather than the interface — necessary to call
+// LoadCredentialsFromEnvironment directly in priority tests.
+func newDispatchTestClient(t *testing.T) *AuthenticatedGitClientImpl {
+	t.Helper()
+	return &AuthenticatedGitClientImpl{
+		cacheManager:        NewCacheManager(),
+		disabledProgressOps: make(map[string]bool),
+		credentialStorage:   make(map[string]storedCredential),
+		credentialCache:     make(map[string]*credentialCacheEntry),
+		wipedMemoryHandles:  make(map[string]bool),
+	}
+}
+
+// isCloneFailedError returns true when the error is a GitOperationError with
+// type "clone_failed" — the error emitted by the plain-clone execution path.
+func isCloneFailedError(err error) bool {
+	var gitErr *outbound.GitOperationError
+	return errors.As(err, &gitErr) && gitErr.Type == "clone_failed"
+}
+
+// isEnvCredentialLoadError returns true when the error carries the type that
+// LoadCredentialsFromEnvironment returns for non-"not-found" failures such as
+// "env_token_invalid".  Clone() must propagate these upward unchanged.
+func isEnvCredentialLoadError(err error, expectedType string) bool {
+	var gitErr *outbound.GitOperationError
+	return errors.As(err, &gitErr) && gitErr.Type == expectedType
+}
+
+// clearAllAuthEnvVars removes every env variable that LoadCredentialsFromEnvironment
+// consults so that each test starts from a known-clean baseline.
+// Must be called before t.Setenv to avoid the parallel-conflict restriction.
+func clearAllAuthEnvVars(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		"GITHUB_TOKEN", "GITHUB_USERNAME",
+		"GITLAB_TOKEN", "GITLAB_USERNAME",
+		"GIT_TOKEN", "GIT_USERNAME",
+		"SSH_KEY_PATH", "SSH_KEY_PASSPHRASE",
+	} {
+		t.Setenv(key, "")
+	}
+}
+
+// ----------------------------------------------------------------------------
+// TestCloneAuthDispatch — primary test suite
+// ----------------------------------------------------------------------------
+
+// TestCloneAuthDispatch_GitLabToken_DelegatesToCloneWithTokenAuth verifies that
+// when GITLAB_TOKEN is set and the URL targets gitlab.com, Clone() delegates to
+// CloneWithTokenAuth rather than executing a raw git clone.
+//
+// CloneWithTokenAuth is a stub that returns a mock success without touching the
+// network.  The old Clone() implementation runs exec.Command("git", "clone", ...)
+// which fails against non-existent URLs.
+//
+// Contract: Clone() with a valid GITLAB_TOKEN for a gitlab.com URL must return nil.
+// Current failure: returns a clone_failed error (real git is invoked).
+func TestCloneAuthDispatch_GitLabToken_DelegatesToCloneWithTokenAuth(t *testing.T) {
+	clearAllAuthEnvVars(t)
+	t.Setenv("GITLAB_TOKEN", "glpat-testtoken123456789")
+
+	client := newDispatchTestClient(t)
+	ctx := context.Background()
+	targetPath := t.TempDir()
+
+	err := client.Clone(ctx, "https://gitlab.com/nonexistent-org/nonexistent-repo.git", targetPath)
+	// After refactor: CloneWithTokenAuth stub returns success → Clone returns nil.
+	// Current (old) implementation: real git clone fails → returns clone_failed error.
+	if err != nil {
+		t.Errorf(
+			"Clone() with valid GITLAB_TOKEN must delegate to CloneWithTokenAuth (stub success), "+
+				"but got error: %v — this confirms Clone() is still running real git instead of dispatching",
+			err,
+		)
+	}
+}
+
+// TestCloneAuthDispatch_GitLabToken_WrongHost_FallsThroughToPlainClone verifies
+// that when GITLAB_TOKEN is set but the URL targets github.com (not gitlab.com),
+// LoadCredentialsFromEnvironment returns env_credentials_not_found for that URL,
+// and Clone() falls through to a plain (unauthenticated) git clone.
+//
+// A plain git clone against a non-existent URL returns a clone_failed error.
+// The token must NOT be applied cross-host.
+func TestCloneAuthDispatch_GitLabToken_WrongHost_FallsThroughToPlainClone(t *testing.T) {
+	clearAllAuthEnvVars(t)
+	t.Setenv("GITLAB_TOKEN", "glpat-testtoken123456789")
+	// Intentionally do NOT set GITHUB_TOKEN.
+
+	client := newDispatchTestClient(t)
+	ctx := context.Background()
+	targetPath := t.TempDir()
+
+	err := client.Clone(ctx, "https://github.com/nonexistent-org/nonexistent-repo.git", targetPath)
+
+	// Must fail — no credentials for github.com, plain git clone fails.
+	if err == nil {
+		t.Fatal("expected Clone to fail for github.com with only GITLAB_TOKEN set, got nil error")
+	}
+
+	// Must be a plain clone_failed error — GITLAB_TOKEN must not have been applied.
+	if !isCloneFailedError(err) {
+		var gitErr *outbound.GitOperationError
+		if errors.As(err, &gitErr) {
+			t.Errorf(
+				"expected clone_failed for unauthenticated github.com URL, got error type %q — "+
+					"GITLAB_TOKEN must not be applied to github.com URLs; "+
+					"LoadCredentialsFromEnvironment scopes it to gitlab.com only",
+				gitErr.Type,
+			)
+		} else {
+			t.Errorf("expected *outbound.GitOperationError with type clone_failed, got %T: %v", err, err)
+		}
+	}
+}
+
+// TestCloneAuthDispatch_GitHubToken_DelegatesToCloneWithTokenAuth verifies that
+// GITHUB_TOKEN for a github.com URL causes Clone() to delegate to CloneWithTokenAuth.
+//
+// Contract: Clone() with a valid GITHUB_TOKEN for github.com must return nil (stub success).
+// Current failure: returns a clone_failed error (real git is invoked).
+func TestCloneAuthDispatch_GitHubToken_DelegatesToCloneWithTokenAuth(t *testing.T) {
+	clearAllAuthEnvVars(t)
+	t.Setenv("GITHUB_TOKEN", "ghp_testtoken1234567890abcdef12345678")
+
+	client := newDispatchTestClient(t)
+	ctx := context.Background()
+	targetPath := t.TempDir()
+
+	err := client.Clone(ctx, "https://github.com/nonexistent-org/nonexistent-repo.git", targetPath)
+	// After refactor: stub success → nil.
+	// Current: real git clone fails.
+	if err != nil {
+		t.Errorf(
+			"Clone() with valid GITHUB_TOKEN must delegate to CloneWithTokenAuth (stub success), "+
+				"but got error: %v",
+			err,
+		)
+	}
+}
+
+// TestCloneAuthDispatch_GenericGitToken_DelegatesToCloneWithTokenAuth verifies
+// that GIT_TOKEN (the provider-agnostic fallback) causes Clone() to delegate to
+// CloneWithTokenAuth for a non-github/gitlab URL.
+//
+// Contract: Clone() with a valid GIT_TOKEN must return nil (stub success).
+// Current failure: returns a clone_failed error (real git is invoked).
+func TestCloneAuthDispatch_GenericGitToken_DelegatesToCloneWithTokenAuth(t *testing.T) {
+	clearAllAuthEnvVars(t)
+	// Use a URL that won't match github.com or gitlab.com so only GIT_TOKEN fires.
+	t.Setenv("GIT_TOKEN", "generic-valid-token-abc123")
+
+	client := newDispatchTestClient(t)
+	ctx := context.Background()
+	targetPath := t.TempDir()
+
+	err := client.Clone(ctx, "https://bitbucket.org/nonexistent-org/nonexistent-repo.git", targetPath)
+	// After refactor: stub success → nil.
+	// Current: real git clone fails.
+	if err != nil {
+		t.Errorf(
+			"Clone() with valid GIT_TOKEN must delegate to CloneWithTokenAuth (stub success), "+
+				"but got error: %v",
+			err,
+		)
+	}
+}
+
+// TestCloneAuthDispatch_SSHKeyPath_DelegatesToCloneWithSSHAuth verifies that
+// when SSH_KEY_PATH is set and no token vars are present, Clone() dispatches to
+// CloneWithSSHAuth rather than attempting a plain git clone.
+//
+// CloneWithSSHAuth is a stub that returns mock success without network access.
+//
+// Contract: Clone() with SSH_KEY_PATH set must return nil (stub success).
+// Current failure: Clone() ignores SSH_KEY_PATH entirely; plain git clone runs and fails.
+func TestCloneAuthDispatch_SSHKeyPath_DelegatesToCloneWithSSHAuth(t *testing.T) {
+	clearAllAuthEnvVars(t)
+
+	// Create a real file so LoadCredentialsFromEnvironment finds it and returns SSHAuthConfig.
+	keyFile, createErr := os.CreateTemp(t.TempDir(), "test_ssh_key_*")
+	if createErr != nil {
+		t.Fatalf("failed to create temp SSH key file: %v", createErr)
+	}
+	keyPath := keyFile.Name()
+	keyFile.Close()
+	t.Cleanup(func() { os.Remove(keyPath) })
+
+	t.Setenv("SSH_KEY_PATH", keyPath)
+
+	client := newDispatchTestClient(t)
+	ctx := context.Background()
+	targetPath := t.TempDir()
+
+	err := client.Clone(ctx, "git@nonexistent.example.com:org/repo.git", targetPath)
+	// After refactor: CloneWithSSHAuth stub returns success → Clone returns nil.
+	// Current: Clone() ignores SSH_KEY_PATH; real git clone runs and fails.
+	if err != nil {
+		t.Errorf(
+			"Clone() with SSH_KEY_PATH set must delegate to CloneWithSSHAuth (stub success), "+
+				"but got error: %v — Clone() is not dispatching to CloneWithSSHAuth",
+			err,
+		)
+	}
+}
+
+// TestCloneAuthDispatch_NoCredentials_PlainCloneFails verifies the no-credentials
+// case: when no auth env vars are set, LoadCredentialsFromEnvironment returns
+// env_credentials_not_found and Clone() must fall through to a plain git clone.
+//
+// A plain git clone against a non-existent URL must return a clone_failed error.
+// This test should pass both before and after the refactor — it validates the
+// fall-through behavior is preserved.
+func TestCloneAuthDispatch_NoCredentials_PlainCloneFails(t *testing.T) {
+	clearAllAuthEnvVars(t)
+
+	client := newDispatchTestClient(t)
+	ctx := context.Background()
+	targetPath := t.TempDir()
+
+	err := client.Clone(ctx, "https://github.com/nonexistent-org/nonexistent-repo.git", targetPath)
+
+	// Must fail — no credentials, no network, plain git clone.
+	if err == nil {
+		t.Fatal("expected Clone to fail without credentials, got nil error")
+	}
+
+	// Must be a clone_failed error — env_credentials_not_found must NOT be
+	// propagated; it is a sentinel that means "proceed without auth".
+	if !isCloneFailedError(err) {
+		var gitErr *outbound.GitOperationError
+		if errors.As(err, &gitErr) {
+			t.Errorf(
+				"expected clone_failed for plain clone path, got error type %q — "+
+					"env_credentials_not_found must trigger fall-through to plain clone, not be returned",
+				gitErr.Type,
+			)
+		} else {
+			t.Errorf("expected *outbound.GitOperationError with type clone_failed, got %T: %v", err, err)
+		}
+	}
+}
+
+// TestCloneAuthDispatch_InvalidTokenFormat_PropagatesError verifies that when
+// LoadCredentialsFromEnvironment returns a non-"env_credentials_not_found" error
+// (e.g., "env_token_invalid" for a malformed token), Clone() must propagate that
+// error upward immediately instead of falling through to a plain clone.
+//
+// Current failure: Clone() ignores LoadCredentialsFromEnvironment entirely,
+// runs a real git clone, and returns clone_failed instead of env_token_invalid.
+func TestCloneAuthDispatch_InvalidTokenFormat_PropagatesError(t *testing.T) {
+	clearAllAuthEnvVars(t)
+	// "invalid-token-format" is the sentinel value that causes LoadCredentialsFromEnvironment
+	// to return an env_token_invalid error (see the InvalidTokenFormat constant).
+	t.Setenv("GIT_TOKEN", InvalidTokenFormat)
+
+	client := newDispatchTestClient(t)
+	ctx := context.Background()
+	targetPath := t.TempDir()
+
+	err := client.Clone(ctx, "https://github.com/nonexistent-org/nonexistent-repo.git", targetPath)
+
+	if err == nil {
+		t.Fatal("expected Clone to propagate token-invalid error, got nil")
+	}
+
+	// The error must be "env_token_invalid", not "clone_failed".
+	// "clone_failed" here means Clone silently fell through to a plain git clone
+	// despite encountering a real credential format error — that is wrong behavior.
+	if !isEnvCredentialLoadError(err, "env_token_invalid") {
+		var gitErr *outbound.GitOperationError
+		if errors.As(err, &gitErr) {
+			t.Errorf(
+				"Clone() must propagate env_token_invalid from LoadCredentialsFromEnvironment, "+
+					"got %q — non-not-found credential errors must be returned immediately, "+
+					"not silently fallen through to plain clone",
+				gitErr.Type,
+			)
+		} else {
+			t.Errorf(
+				"expected *outbound.GitOperationError with type env_token_invalid, got %T: %v",
+				err, err,
+			)
+		}
+	}
+}
+
+// TestCloneAuthDispatch_CredentialDispatchPriority verifies that provider-specific
+// tokens take priority over generic GIT_TOKEN when multiple env vars are set,
+// and that Clone() dispatches through the highest-priority credential.
+//
+// For a github.com URL with both GITHUB_TOKEN and GIT_TOKEN set:
+//   - LoadCredentialsFromEnvironment must return the GITHUB_TOKEN config (provider=github)
+//   - Clone() must dispatch to CloneWithTokenAuth with that config
+//   - Result: stub success → Clone returns nil
+//
+// This test confirms the priority contract of LoadCredentialsFromEnvironment is
+// respected by Clone()'s dispatch logic.
+func TestCloneAuthDispatch_CredentialDispatchPriority(t *testing.T) {
+	clearAllAuthEnvVars(t)
+	t.Setenv("GITHUB_TOKEN", "ghp_prioritytoken123456789abcdef123456")
+	t.Setenv("GIT_TOKEN", "generic-lower-priority-token")
+
+	client := newDispatchTestClient(t)
+	ctx := context.Background()
+
+	// First verify that LoadCredentialsFromEnvironment itself returns the correct
+	// priority — if this assertion fails the dispatch test would be misleading.
+	resolved, credErr := client.LoadCredentialsFromEnvironment(
+		ctx,
+		"https://github.com/nonexistent-org/nonexistent-repo.git",
+	)
+	if credErr != nil {
+		t.Fatalf(
+			"LoadCredentialsFromEnvironment must return GITHUB_TOKEN for github.com URL, got error: %v",
+			credErr,
+		)
+	}
+	tokenCfg, ok := resolved.(*outbound.TokenAuthConfig)
+	if !ok {
+		t.Fatalf("expected *outbound.TokenAuthConfig from LoadCredentialsFromEnvironment, got %T", resolved)
+	}
+	if tokenCfg.Provider != "github" {
+		t.Errorf(
+			"LoadCredentialsFromEnvironment must return provider 'github' for github.com URL "+
+				"when GITHUB_TOKEN is set, got %q — this is a prerequisite for dispatch priority",
+			tokenCfg.Provider,
+		)
+	}
+
+	// Now verify Clone() dispatches through the highest-priority credential.
+	// After refactor: CloneWithTokenAuth stub returns success → Clone returns nil.
+	// Current: real git clone runs and returns an error.
+	targetPath := t.TempDir()
+	err := client.Clone(ctx, "https://github.com/nonexistent-org/nonexistent-repo.git", targetPath)
+	if err != nil {
+		t.Errorf(
+			"Clone() must delegate to CloneWithTokenAuth (stub success) when GITHUB_TOKEN is set, "+
+				"but got error: %v — Clone() is not dispatching through LoadCredentialsFromEnvironment",
+			err,
+		)
+	}
+}
+
+// TestCloneAuthDispatch_TokenAuthConfig_OldInlineInjectionAbsent is a direct
+// regression test for the specific old behavior being replaced.
+//
+// The old Clone() implementation:
+//  1. Reads GITLAB_TOKEN via os.Getenv directly
+//  2. Builds a cmd.Env with GIT_CONFIG_COUNT/GIT_CONFIG_KEY_0/GIT_CONFIG_VALUE_0
+//  3. Runs exec.Command("git", "clone", ...) with those env vars on the child process
+//
+// The new Clone() must NOT do step 2-3 itself — it must delegate to CloneWithTokenAuth.
+//
+// Observable difference: old path fails with "clone_failed" (real git runs);
+// new path succeeds with nil (CloneWithTokenAuth stub returns mock result).
+func TestCloneAuthDispatch_TokenAuthConfig_OldInlineInjectionAbsent(t *testing.T) {
+	clearAllAuthEnvVars(t)
+	t.Setenv("GITLAB_TOKEN", "glpat-refactortest123456789")
+
+	client := newDispatchTestClient(t)
+	ctx := context.Background()
+	targetPath := t.TempDir()
+
+	err := client.Clone(ctx, "https://gitlab.com/nonexistent-org/nonexistent-repo.git", targetPath)
+	// After refactor: Clone → LoadCredentialsFromEnvironment → TokenAuthConfig
+	//               → CloneWithTokenAuth(stub) → returns nil
+	//
+	// Current (before refactor): Clone → os.Getenv("GITLAB_TOKEN") → injects
+	//   GIT_CONFIG_* onto cmd.Env → exec.Command git clone → fails → clone_failed error
+	if err != nil {
+		t.Errorf(
+			"Clone() with GITLAB_TOKEN must delegate to CloneWithTokenAuth (stub success, nil error), "+
+				"got: %v — this confirms the old inline GIT_CONFIG injection path is still active "+
+				"instead of dispatching through LoadCredentialsFromEnvironment",
+			err,
+		)
+	}
+}

--- a/internal/adapter/outbound/gitprovider/gitlab_provider.go
+++ b/internal/adapter/outbound/gitprovider/gitlab_provider.go
@@ -1,10 +1,12 @@
 package gitprovider
 
 import (
+	"codechunking/internal/application/common/slogger"
 	"codechunking/internal/domain/entity"
 	"codechunking/internal/port/outbound"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -41,11 +43,15 @@ func (p *GitLabProvider) ListRepositories(
 	seen := make(map[string]struct{})
 	var result []outbound.GitProviderRepository
 
-	// List projects from each group.
+	// List projects from each group, skipping groups that fail so one bad group
+	// (e.g. a moved/deleted group) doesn't abort the entire sync.
+	var groupErrs []error
 	for _, group := range connector.Groups() {
 		repos, err := p.listGroupProjects(ctx, baseURL, group, connector.AuthToken())
 		if err != nil {
-			return nil, fmt.Errorf("listing group %q: %w", group, err)
+			slogger.Warn(ctx, "Skipping group due to error", slogger.Fields{"group": group, "error": err.Error()})
+			groupErrs = append(groupErrs, fmt.Errorf("listing group %q: %w", group, err))
+			continue
 		}
 		for _, repo := range repos {
 			if _, dup := seen[repo.URL]; dup {
@@ -54,6 +60,13 @@ func (p *GitLabProvider) ListRepositories(
 			seen[repo.URL] = struct{}{}
 			result = append(result, repo)
 		}
+	}
+	// Only declare a hard failure when groups are the *only* configured signal: at least one
+	// group erred (1), nothing succeeded (2), and there's no individual project that might
+	// still produce a result (3). If any of those escape hatches exist, prefer partial success
+	// — the per-group warnings were already logged above.
+	if len(groupErrs) > 0 && len(result) == 0 && len(connector.Projects()) == 0 {
+		return nil, errors.Join(groupErrs...)
 	}
 
 	// Fetch individually specified projects.

--- a/internal/adapter/outbound/gitprovider/gitlab_provider_test.go
+++ b/internal/adapter/outbound/gitprovider/gitlab_provider_test.go
@@ -532,6 +532,116 @@ func TestListGroupProjects_GroupPathIsURLEncoded(t *testing.T) {
 		"group path with slash must be URL-encoded in the request path; got %s", receivedURIs[0])
 }
 
+// TestListGroupProjects_OneGroupFailsOtherSucceeds verifies that when one group returns
+// a 404 and another group succeeds, the function returns the repos from the successful
+// group without error. The failing group should be skipped (logged as a warning) rather
+// than aborting the entire operation.
+func TestListGroupProjects_OneGroupFailsOtherSucceeds(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "missing-group") {
+			// Simulate a 404 for the first group - it doesn't exist.
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"message":"404 Group Not Found"}`))
+			return
+		}
+		// The second group returns successfully.
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(encodeJSON(t, []stubProject{
+			publicProject("surviving-repo", "https://gl.example.com/good-group/surviving-repo.git"),
+		}))
+	}))
+	defer srv.Close()
+
+	provider := NewGitLabProvider(srv.Client())
+	// missing-group will 404; good-group will succeed.
+	connector := newTestConnector(t, srv.URL, nil, []string{"missing-group", "good-group"})
+
+	got, err := provider.ListRepositories(context.Background(), connector)
+
+	// Partial success: no error because at least one group worked.
+	require.NoError(t, err, "a single 404 group must not abort the whole operation when another group succeeds")
+	require.Len(t, got, 1, "only the repos from the successful group must be returned")
+	assert.Equal(t, "surviving-repo", got[0].Name)
+}
+
+// TestListGroupProjects_SuccessfulGroupBeforeFailingGroup verifies that repos from a
+// successful group are returned even when a subsequent group fails, confirming that
+// iteration order does not affect partial-success behaviour.
+func TestListGroupProjects_SuccessfulGroupBeforeFailingGroup(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "broken-group") {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"message":"404 Group Not Found"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(encodeJSON(t, []stubProject{
+			publicProject("first-repo", "https://gl.example.com/working-group/first-repo.git"),
+		}))
+	}))
+	defer srv.Close()
+
+	provider := NewGitLabProvider(srv.Client())
+	// working-group succeeds first, then broken-group fails.
+	connector := newTestConnector(t, srv.URL, nil, []string{"working-group", "broken-group"})
+
+	got, err := provider.ListRepositories(context.Background(), connector)
+
+	require.NoError(t, err, "a trailing 404 group must not discard repos already fetched from earlier groups")
+	require.Len(t, got, 1)
+	assert.Equal(t, "first-repo", got[0].Name)
+}
+
+// TestListGroupProjects_AllGroupsFailReturnsError verifies that when every configured
+// group returns an error, ListRepositories itself returns an error (and no repositories).
+func TestListGroupProjects_AllGroupsFailReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Every group gets a 404.
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"404 Group Not Found"}`))
+	}))
+	defer srv.Close()
+
+	provider := NewGitLabProvider(srv.Client())
+	connector := newTestConnector(t, srv.URL, nil, []string{"ghost-group-a", "ghost-group-b"})
+
+	got, err := provider.ListRepositories(context.Background(), connector)
+
+	require.Error(t, err, "all groups failing must produce an error")
+	assert.Empty(t, got, "no repositories must be returned when every group fails")
+}
+
+// TestListGroupProjects_MultipleFailingGroupsPartialSuccessReturnsAll verifies that
+// when two out of three groups fail, the repos from the one successful group are
+// returned and no error is raised.
+func TestListGroupProjects_MultipleFailingGroupsPartialSuccessReturnsAll(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "alive-group") {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(encodeJSON(t, []stubProject{
+				publicProject("alive-repo", "https://gl.example.com/alive-group/alive-repo.git"),
+			}))
+			return
+		}
+		// dead-group-1 and dead-group-2 both 404.
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"404 Group Not Found"}`))
+	}))
+	defer srv.Close()
+
+	provider := NewGitLabProvider(srv.Client())
+	connector := newTestConnector(t, srv.URL, nil, []string{"dead-group-1", "alive-group", "dead-group-2"})
+
+	got, err := provider.ListRepositories(context.Background(), connector)
+
+	require.NoError(t, err, "partial success (one working group out of three) must not return an error")
+	require.Len(t, got, 1)
+	assert.Equal(t, "alive-repo", got[0].Name)
+}
+
 // TestListGroupProjects_MultipleGroupsAggregated verifies that when a connector has
 // multiple groups, repositories from each group are all returned in a single result set.
 func TestListGroupProjects_MultipleGroupsAggregated(t *testing.T) {
@@ -565,4 +675,41 @@ func TestListGroupProjects_MultipleGroupsAggregated(t *testing.T) {
 	}
 	assert.Contains(t, names, "a1")
 	assert.Contains(t, names, "b1")
+}
+
+// TestListGroupProjects_AllGroupsFail_ProjectsNonEmpty_DoesNotAbortEarly locks in the
+// third condition of the partial-fail guard: when every group errors but the connector
+// also lists an individual project, ListRepositories must return that project without
+// error instead of surfacing the group errors.
+func TestListGroupProjects_AllGroupsFail_ProjectsNonEmpty_DoesNotAbortEarly(t *testing.T) {
+	project := publicProject("my-project", "https://gitlab.example.com/my-group/my-project.git")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "/groups/") {
+			http.Error(w, `{"message":"404 Not found"}`, http.StatusNotFound)
+			return
+		}
+		// Individual project endpoint — serves the project payload.
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(encodeJSON(t, project))
+	}))
+	defer srv.Close()
+
+	connector, err := entity.NewConnector(
+		"test-connector",
+		valueobject.ConnectorTypeGitLab,
+		srv.URL,
+		nil,
+		[]string{"my-group"},            // will 404
+		[]string{"my-group/my-project"}, // individual project that succeeds
+	)
+	require.NoError(t, err)
+
+	provider := NewGitLabProvider(srv.Client())
+	got, gotErr := provider.ListRepositories(context.Background(), connector)
+
+	require.NoError(t, gotErr, "group failures must not surface as an error when projects are non-empty")
+	require.Len(t, got, 1, "the individual project must be returned despite the group failure")
+	assert.Equal(t, "my-project", got[0].Name)
 }

--- a/internal/application/worker/job_processor.go
+++ b/internal/application/worker/job_processor.go
@@ -842,7 +842,8 @@ func (p *DefaultJobProcessor) setupWorkspace(workspacePath string) error {
 	return nil
 }
 
-// cloneRepository clones the repository.
+// cloneRepository clones the repository. If GITLAB_TOKEN is set, it is passed
+// to git as an HTTP extra header so that credentials are never embedded in the URL.
 func (p *DefaultJobProcessor) cloneRepository(
 	ctx context.Context,
 	message messaging.EnhancedIndexingJobMessage,

--- a/migrations/000003_optimize_vector_storage_partitioning.up.sql
+++ b/migrations/000003_optimize_vector_storage_partitioning.up.sql
@@ -44,65 +44,57 @@ CREATE TABLE embeddings_partitioned_3 PARTITION OF embeddings_partitioned
 
 -- Create HNSW indexes on each partition for optimal vector search
 -- Using optimal parameters: m=16, ef_construction=64, cosine similarity
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_embeddings_partitioned_0_vector 
+CREATE INDEX IF NOT EXISTS idx_embeddings_partitioned_0_vector 
     ON embeddings_partitioned_0 
     USING hnsw (embedding vector_cosine_ops)
     WITH (m = 16, ef_construction = 64);
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_embeddings_partitioned_1_vector 
+CREATE INDEX IF NOT EXISTS idx_embeddings_partitioned_1_vector 
     ON embeddings_partitioned_1 
     USING hnsw (embedding vector_cosine_ops)
     WITH (m = 16, ef_construction = 64);
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_embeddings_partitioned_2_vector 
+CREATE INDEX IF NOT EXISTS idx_embeddings_partitioned_2_vector 
     ON embeddings_partitioned_2 
     USING hnsw (embedding vector_cosine_ops)
     WITH (m = 16, ef_construction = 64);
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_embeddings_partitioned_3_vector 
+CREATE INDEX IF NOT EXISTS idx_embeddings_partitioned_3_vector 
     ON embeddings_partitioned_3 
     USING hnsw (embedding vector_cosine_ops)
     WITH (m = 16, ef_construction = 64);
 
 -- Create supporting indexes on each partition
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_embeddings_partitioned_0_chunk_id 
+CREATE INDEX IF NOT EXISTS idx_embeddings_partitioned_0_chunk_id 
     ON embeddings_partitioned_0 (chunk_id);
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_embeddings_partitioned_0_repository_id 
+CREATE INDEX IF NOT EXISTS idx_embeddings_partitioned_0_repository_id 
     ON embeddings_partitioned_0 (repository_id);
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_embeddings_partitioned_0_deleted_at 
+CREATE INDEX IF NOT EXISTS idx_embeddings_partitioned_0_deleted_at 
     ON embeddings_partitioned_0 (deleted_at);
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_embeddings_partitioned_1_chunk_id 
+CREATE INDEX IF NOT EXISTS idx_embeddings_partitioned_1_chunk_id 
     ON embeddings_partitioned_1 (chunk_id);
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_embeddings_partitioned_1_repository_id 
+CREATE INDEX IF NOT EXISTS idx_embeddings_partitioned_1_repository_id 
     ON embeddings_partitioned_1 (repository_id);
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_embeddings_partitioned_1_deleted_at 
+CREATE INDEX IF NOT EXISTS idx_embeddings_partitioned_1_deleted_at 
     ON embeddings_partitioned_1 (deleted_at);
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_embeddings_partitioned_2_chunk_id 
+CREATE INDEX IF NOT EXISTS idx_embeddings_partitioned_2_chunk_id 
     ON embeddings_partitioned_2 (chunk_id);
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_embeddings_partitioned_2_repository_id 
+CREATE INDEX IF NOT EXISTS idx_embeddings_partitioned_2_repository_id 
     ON embeddings_partitioned_2 (repository_id);
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_embeddings_partitioned_2_deleted_at 
+CREATE INDEX IF NOT EXISTS idx_embeddings_partitioned_2_deleted_at 
     ON embeddings_partitioned_2 (deleted_at);
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_embeddings_partitioned_3_chunk_id 
+CREATE INDEX IF NOT EXISTS idx_embeddings_partitioned_3_chunk_id 
     ON embeddings_partitioned_3 (chunk_id);
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_embeddings_partitioned_3_repository_id 
+CREATE INDEX IF NOT EXISTS idx_embeddings_partitioned_3_repository_id 
     ON embeddings_partitioned_3 (repository_id);
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_embeddings_partitioned_3_deleted_at 
+CREATE INDEX IF NOT EXISTS idx_embeddings_partitioned_3_deleted_at 
     ON embeddings_partitioned_3 (deleted_at);
 
 -- ==============================================================================
--- 3. PERFORMANCE TUNING CONFIGURATION
--- ==============================================================================
-
--- Optimize HNSW search parameters for better recall
--- These can be adjusted at runtime based on performance requirements
-ALTER SYSTEM SET hnsw.ef_search = 100; -- Higher recall, slightly slower queries
-
--- ==============================================================================
--- 4. PARTITION MANAGEMENT FUNCTIONS
+-- 3. PARTITION MANAGEMENT FUNCTIONS
 -- ==============================================================================
 
 -- Function to add new partitions dynamically
@@ -117,20 +109,20 @@ BEGIN
     EXECUTE sql_statement;
     
     -- Add HNSW vector index
-    sql_statement := format('CREATE INDEX CONCURRENTLY %I ON %I USING hnsw (embedding vector_cosine_ops) WITH (m = 16, ef_construction = 64)', 
+    sql_statement := format('CREATE INDEX %I ON %I USING hnsw (embedding vector_cosine_ops) WITH (m = 16, ef_construction = 64)', 
                            'idx_' || partition_name || '_vector', partition_name);
     EXECUTE sql_statement;
     
     -- Add supporting indexes
-    sql_statement := format('CREATE INDEX CONCURRENTLY %I ON %I (chunk_id)', 
+    sql_statement := format('CREATE INDEX %I ON %I (chunk_id)', 
                            'idx_' || partition_name || '_chunk_id', partition_name);
     EXECUTE sql_statement;
     
-    sql_statement := format('CREATE INDEX CONCURRENTLY %I ON %I (repository_id)', 
+    sql_statement := format('CREATE INDEX %I ON %I (repository_id)', 
                            'idx_' || partition_name || '_repository_id', partition_name);
     EXECUTE sql_statement;
     
-    sql_statement := format('CREATE INDEX CONCURRENTLY %I ON %I (deleted_at)', 
+    sql_statement := format('CREATE INDEX %I ON %I (deleted_at)', 
                            'idx_' || partition_name || '_deleted_at', partition_name);
     EXECUTE sql_statement;
 END;
@@ -147,21 +139,18 @@ RETURNS TABLE(
 BEGIN
     RETURN QUERY
     SELECT 
-        -- NOTE: `tablename` is the original column name used here but pg_stat_user_tables
-        -- actually exposes this column as `relname`. This query will return no rows on
-        -- standard PostgreSQL. The column reference is corrected in migration 000019.
-        schemaname||'.'||tablename as partition_name,
+        schemaname||'.'||relname as partition_name,
         n_tup_ins - n_tup_del as row_count,
-        pg_size_pretty(pg_total_relation_size(schemaname||'.'||tablename)) as size_pretty,
-        pg_size_pretty(pg_indexes_size(schemaname||'.'||tablename)) as index_size_pretty
+        pg_size_pretty(pg_total_relation_size(schemaname||'.'||relname)) as size_pretty,
+        pg_size_pretty(pg_indexes_size(schemaname||'.'||relname)) as index_size_pretty
     FROM pg_stat_user_tables 
-    WHERE tablename LIKE 'embeddings_partitioned_%'  -- fixed to `relname` in migration 000019
-    ORDER BY tablename;                              -- fixed to `relname` in migration 000019
+    WHERE relname LIKE 'embeddings_partitioned_%'
+    ORDER BY relname;
 END;
 $$ LANGUAGE plpgsql;
 
 -- ==============================================================================
--- 5. FOREIGN KEY CONSTRAINTS (DEFERRED FOR PERFORMANCE)
+-- 4. FOREIGN KEY CONSTRAINTS (DEFERRED FOR PERFORMANCE)
 -- ==============================================================================
 
 -- Note: The FK constraint fk_embeddings_partitioned_chunk_id was intentionally
@@ -170,7 +159,7 @@ $$ LANGUAGE plpgsql;
 -- the same constraint with proper DEFERRABLE semantics.
 
 -- ==============================================================================
--- 6. COMMENTS AND DOCUMENTATION
+-- 5. COMMENTS AND DOCUMENTATION
 -- ==============================================================================
 
 COMMENT ON TABLE embeddings_partitioned IS 
@@ -186,18 +175,16 @@ COMMENT ON FUNCTION get_embeddings_partition_stats() IS
 'Monitoring function to track partition sizes and row counts for capacity planning.';
 
 -- ==============================================================================
--- 7. PERFORMANCE MONITORING VIEW
+-- 6. PERFORMANCE MONITORING VIEW
 -- ==============================================================================
 
 -- Create view for monitoring partition performance
--- NOTE: `tablename` below is the original (non-functional) column reference;
--- pg_stat_user_tables exposes this as `relname`. The view is corrected in migration 000019.
 CREATE OR REPLACE VIEW embeddings_partition_monitoring AS
 SELECT 
-    schemaname||'.'||tablename as partition_name,   -- fixed to `relname` in migration 000019
+    schemaname||'.'||relname as partition_name,
     n_tup_ins - n_tup_del as row_count,
-    pg_size_pretty(pg_total_relation_size(schemaname||'.'||tablename)) as size_pretty,
-    pg_size_pretty(pg_indexes_size(schemaname||'.'||tablename)) as index_size_pretty,
+    pg_size_pretty(pg_total_relation_size(schemaname||'.'||relname)) as size_pretty,
+    pg_size_pretty(pg_indexes_size(schemaname||'.'||relname)) as index_size_pretty,
     seq_scan,
     seq_tup_read,
     idx_scan,
@@ -206,8 +193,8 @@ SELECT
     n_tup_upd,
     n_tup_del
 FROM pg_stat_user_tables 
-WHERE tablename LIKE 'embeddings_partitioned_%'  -- fixed to `relname` in migration 000019
-ORDER BY tablename;                              -- fixed to `relname` in migration 000019
+WHERE relname LIKE 'embeddings_partitioned_%'
+ORDER BY relname;
 
 COMMENT ON VIEW embeddings_partition_monitoring IS 
 'Performance monitoring view for embeddings partitions showing size, usage, and access patterns.';


### PR DESCRIPTION
- Trigger background sync for all active connectors on API startup.
- Improve GitLab provider to skip failing groups instead of aborting the entire sync.
- Inject GITLAB_TOKEN into repository URLs for cloning if available.
- Build Zoekt from source in Docker for multi-arch compatibility.
- Update migration 000003 to support non-transactional execution and fix column names.